### PR TITLE
fix: wrong key used to delete subscriptions from socket on complete

### DIFF
--- a/lib/absinthe/graphql_ws/transport.ex
+++ b/lib/absinthe/graphql_ws/transport.ex
@@ -193,7 +193,7 @@ defmodule Absinthe.GraphqlWS.Transport do
         Phoenix.PubSub.unsubscribe(socket.pubsub, topic)
         Absinthe.Subscription.unsubscribe(socket.endpoint, topic)
 
-        {:ok, %{socket | subscriptions: Map.delete(socket.subscriptions, id)}}
+        {:ok, %{socket | subscriptions: Map.delete(socket.subscriptions, topic)}}
 
       _ ->
         {:ok, socket}


### PR DESCRIPTION
The `subscriptions` field maps topics to subscription ids, so we must delete the topic from the map to remove a subscription.