### PR TITLE
chore: switch local toolchain management from asdf to mise

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,12 +28,12 @@ jobs:
         uses: actions/cache@v2
         with:
           path: deps
-          key: ${{ runner.os }}-test-deps-v1-${{ hashFiles('**/mix.lock', '.tool-versions') }}
+          key: ${{ runner.os }}-test-deps-v1-${{ hashFiles('**/mix.lock', 'mise.toml') }}
       - name: Cache _build
         uses: actions/cache@v2
         with:
           path: _build
-          key: ${{ runner.os }}-test-build-v1-${{ hashFiles('**/mix.lock', '.tool-versions') }}
+          key: ${{ runner.os }}-test-build-v1-${{ hashFiles('**/mix.lock', 'mise.toml') }}
       - name: Install dependencies
         run: mix deps.get
         working-directory: .
@@ -56,12 +56,12 @@ jobs:
         uses: actions/cache@v2
         with:
           path: deps
-          key: ${{ runner.os }}-dev-deps-v1-${{ hashFiles('**/mix.lock', '.tool-versions') }}
+          key: ${{ runner.os }}-dev-deps-v1-${{ hashFiles('**/mix.lock', 'mise.toml') }}
       - name: Cache _build
         uses: actions/cache@v2
         with:
           path: _build
-          key: ${{ runner.os }}-dev-build-v1-${{ hashFiles('**/mix.lock', '.tool-versions') }}
+          key: ${{ runner.os }}-dev-build-v1-${{ hashFiles('**/mix.lock', 'mise.toml') }}
       - name: Install dependencies
         run: mix deps.get
         working-directory: .
@@ -85,12 +85,12 @@ jobs:
         uses: actions/cache@v2
         with:
           path: deps
-          key: ${{ runner.os }}-test-deps-v1-${{ hashFiles('**/mix.lock', '.tool-versions') }}
+          key: ${{ runner.os }}-test-deps-v1-${{ hashFiles('**/mix.lock', 'mise.toml') }}
       - name: Cache _build
         uses: actions/cache@v2
         with:
           path: _build
-          key: ${{ runner.os }}-test-build-v1-${{ hashFiles('**/mix.lock', '.tool-versions') }}
+          key: ${{ runner.os }}-test-build-v1-${{ hashFiles('**/mix.lock', 'mise.toml') }}
       - name: Run tests
         run: mix test --color --warnings-as-errors
         working-directory: .
@@ -111,17 +111,17 @@ jobs:
         uses: actions/cache@v2
         with:
           path: deps
-          key: ${{ runner.os }}-test-deps-v1-${{ hashFiles('**/mix.lock', '.tool-versions') }}
+          key: ${{ runner.os }}-test-deps-v1-${{ hashFiles('**/mix.lock', 'mise.toml') }}
       - name: Cache _build
         uses: actions/cache@v2
         with:
           path: _build
-          key: ${{ runner.os }}-test-build-v1-${{ hashFiles('**/mix.lock', '.tool-versions') }}
+          key: ${{ runner.os }}-test-build-v1-${{ hashFiles('**/mix.lock', 'mise.toml') }}
       - name: Cache PLTs
         uses: actions/cache@v2
         with:
           path: priv/plts
-          key: ${{ runner.os }}-test-dialyxir-v1-${{ hashFiles('**/mix.lock', '.tool-versions') }}
+          key: ${{ runner.os }}-test-dialyxir-v1-${{ hashFiles('**/mix.lock', 'mise.toml') }}
       - name: Credo
         run: mix credo --strict
         working-directory: .
@@ -145,12 +145,12 @@ jobs:
         uses: actions/cache@v2
         with:
           path: deps
-          key: ${{ runner.os }}-dev-deps-v1-${{ hashFiles('**/mix.lock', '.tool-versions') }}
+          key: ${{ runner.os }}-dev-deps-v1-${{ hashFiles('**/mix.lock', 'mise.toml') }}
       - name: Cache _build
         uses: actions/cache@v2
         with:
           path: _build
-          key: ${{ runner.os }}-dev-build-v1-${{ hashFiles('**/mix.lock', '.tool-versions') }}
+          key: ${{ runner.os }}-dev-build-v1-${{ hashFiles('**/mix.lock', 'mise.toml') }}
       - name: Check Elixir formatting
         run: mix format --check-formatted
         working-directory: .
@@ -179,12 +179,12 @@ jobs:
         uses: actions/cache@v2
         with:
           path: deps
-          key: ${{ runner.os }}-dev-deps-v1-${{ hashFiles('**/mix.lock', '.tool-versions') }}
+          key: ${{ runner.os }}-dev-deps-v1-${{ hashFiles('**/mix.lock', 'mise.toml') }}
       - name: Cache _build
         uses: actions/cache@v2
         with:
           path: _build
-          key: ${{ runner.os }}-dev-build-v1-${{ hashFiles('**/mix.lock', '.tool-versions') }}
+          key: ${{ runner.os }}-dev-build-v1-${{ hashFiles('**/mix.lock', 'mise.toml') }}
       - name: Publish to Hex
         uses: synchronal/hex-publish-action@v1
         with:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,0 @@
-elixir 1.13.4-otp-24
-erlang 25.0.3

--- a/bin/dev/doctor
+++ b/bin/dev/doctor
@@ -15,21 +15,13 @@ fi
 
 cecho --green "\n▸" --bright-bold-cyan "Running initial doctor checks..."
 
-check "asdf: installed" \
-  "command -v asdf" \
-  "open 'https://asdf-vm.com/#/core-manage-asdf'"
+check "mise: installed" \
+  "command -v mise" \
+  "open 'https://mise.jdx.dev/getting-started.html'"
 
-check "asdf: erlang plugin installed" \
-  "asdf plugin-list | grep erlang" \
-  "asdf plugin-add erlang"
-
-check "asdf: elixir plugin installed" \
-  "asdf plugin-list | grep elixir" \
-  "asdf plugin-add elixir"
-
-check "asdf: tools are installed" \
-  "asdf which erl > /dev/null && asdf which elixir > /dev/null" \
-  "asdf install"
+check "mise: tools are installed" \
+  "mise which erl > /dev/null && mise which elixir > /dev/null" \
+  "mise install"
 
 echo ""
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,3 @@
+[tools]
+erlang = "27.3.4.12"
+elixir = "1.19.5-otp-27"


### PR DESCRIPTION
## Summary
- Replace `.tool-versions` with `mise.toml` for Erlang 27.3.4.12 and Elixir 1.19.5-otp-27
- Update `bin/dev/doctor` to verify mise installation instead of asdf plugins
- Point CI cache keys at `mise.toml` instead of `.tool-versions`

## Test plan
- [ ] Run `mise install` in the repo and confirm `elixir --version` reports 1.19.5 on OTP 27
- [ ] Run `./bin/dev/doctor` and confirm mise checks pass
- [ ] Verify CI workflows still pass on this branch