### PR TITLE
chore(PLA-1414): add unsubscribe performance span, keep lifecycle execute

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
     env:
       MIX_ENV: test
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
         with:
@@ -46,7 +46,7 @@ jobs:
     env:
       MIX_ENV: dev
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
         with:
@@ -75,7 +75,7 @@ jobs:
     env:
       MIX_ENV: test
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
         with:
@@ -101,7 +101,7 @@ jobs:
     env:
       MIX_ENV: test
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
         with:
@@ -135,7 +135,7 @@ jobs:
     env:
       MIX_ENV: dev
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
         with:
@@ -169,7 +169,7 @@ jobs:
       - audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,12 +25,12 @@ jobs:
           elixir-version: ${{ env.ELIXIR_VERSION }}
           otp-version: ${{ env.OTP_VERSION }}
       - name: Cache deps
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: deps
           key: ${{ runner.os }}-test-deps-v1-${{ hashFiles('**/mix.lock', 'mise.toml') }}
       - name: Cache _build
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: _build
           key: ${{ runner.os }}-test-build-v1-${{ hashFiles('**/mix.lock', 'mise.toml') }}
@@ -53,12 +53,12 @@ jobs:
           elixir-version: ${{ env.ELIXIR_VERSION }}
           otp-version: ${{ env.OTP_VERSION }}
       - name: Cache deps
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: deps
           key: ${{ runner.os }}-dev-deps-v1-${{ hashFiles('**/mix.lock', 'mise.toml') }}
       - name: Cache _build
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: _build
           key: ${{ runner.os }}-dev-build-v1-${{ hashFiles('**/mix.lock', 'mise.toml') }}
@@ -82,12 +82,12 @@ jobs:
           elixir-version: ${{ env.ELIXIR_VERSION }}
           otp-version: ${{ env.OTP_VERSION }}
       - name: Cache deps
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: deps
           key: ${{ runner.os }}-test-deps-v1-${{ hashFiles('**/mix.lock', 'mise.toml') }}
       - name: Cache _build
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: _build
           key: ${{ runner.os }}-test-build-v1-${{ hashFiles('**/mix.lock', 'mise.toml') }}
@@ -108,17 +108,17 @@ jobs:
           elixir-version: ${{ env.ELIXIR_VERSION }}
           otp-version: ${{ env.OTP_VERSION }}
       - name: Cache deps
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: deps
           key: ${{ runner.os }}-test-deps-v1-${{ hashFiles('**/mix.lock', 'mise.toml') }}
       - name: Cache _build
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: _build
           key: ${{ runner.os }}-test-build-v1-${{ hashFiles('**/mix.lock', 'mise.toml') }}
       - name: Cache PLTs
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: priv/plts
           key: ${{ runner.os }}-test-dialyxir-v1-${{ hashFiles('**/mix.lock', 'mise.toml') }}
@@ -142,12 +142,12 @@ jobs:
           elixir-version: ${{ env.ELIXIR_VERSION }}
           otp-version: ${{ env.OTP_VERSION }}
       - name: Cache deps
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: deps
           key: ${{ runner.os }}-dev-deps-v1-${{ hashFiles('**/mix.lock', 'mise.toml') }}
       - name: Cache _build
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: _build
           key: ${{ runner.os }}-dev-build-v1-${{ hashFiles('**/mix.lock', 'mise.toml') }}
@@ -176,12 +176,12 @@ jobs:
           elixir-version: ${{ env.ELIXIR_VERSION }}
           otp-version: ${{ env.OTP_VERSION }}
       - name: Cache deps
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: deps
           key: ${{ runner.os }}-dev-deps-v1-${{ hashFiles('**/mix.lock', 'mise.toml') }}
       - name: Cache _build
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: _build
           key: ${{ runner.os }}-dev-build-v1-${{ hashFiles('**/mix.lock', 'mise.toml') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   build_test:
     name: Build Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       MIX_ENV: test
     steps:
@@ -42,7 +42,7 @@ jobs:
         working-directory: .
   build_dev:
     name: Build Dev
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       MIX_ENV: dev
     steps:
@@ -71,7 +71,7 @@ jobs:
   test:
     name: Test
     needs: build_test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       MIX_ENV: test
     steps:
@@ -97,7 +97,7 @@ jobs:
   credo_and_dialyxir:
     name: Credo + Dialyxir
     needs: build_test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       MIX_ENV: test
     steps:
@@ -131,7 +131,7 @@ jobs:
   audit:
     name: Audit
     needs: build_dev
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       MIX_ENV: dev
     steps:
@@ -167,7 +167,7 @@ jobs:
       - test
       - credo_and_dialyxir
       - audit
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Set up Elixir

--- a/lib/absinthe/graphql_ws/transport.ex
+++ b/lib/absinthe/graphql_ws/transport.ex
@@ -231,8 +231,7 @@ defmodule Absinthe.GraphqlWS.Transport do
     |> case do
       {:ok, topic, operation_name} ->
         debug("unsubscribing from topic #{topic}")
-        unsubscribe_topic(socket, topic)
-        emit_complete_success(socket, id, operation_name)
+        unsubscribe_topic_with_telemetry(socket, topic, id, operation_name)
 
         {:ok, %{socket | subscriptions: Map.delete(socket.subscriptions, topic)}}
 
@@ -312,10 +311,6 @@ defmodule Absinthe.GraphqlWS.Transport do
     emit_operation_telemetry([:absinthe_graphql_ws, :handle_inbound, :subscribe], socket, id, operation_name)
   end
 
-  defp emit_complete_success(socket, id, operation_name) do
-    emit_operation_telemetry([:absinthe_graphql_ws, :handle_inbound, :complete], socket, id, operation_name)
-  end
-
   defp emit_terminate_telemetry(socket, reason) do
     subscriptions =
       Enum.map(socket.subscriptions, fn {topic, _} ->
@@ -339,22 +334,98 @@ defmodule Absinthe.GraphqlWS.Transport do
 
   defp emit_operation_telemetry(event, socket, id, operation_name, extra \\ %{}) do
     metadata =
-      %{
-        platform: get_platform(socket),
-        session_id: get_session_id(socket),
-        client_app_version: get_client_app_version(socket),
-        user_id: get_user_id(socket),
-        id: id,
-        operation_name: operation_name
-      }
+      socket
+      |> operation_metadata(id, operation_name)
       |> Map.merge(extra)
 
     :telemetry.execute(event, %{}, metadata)
   end
 
+  defp operation_metadata(socket, id, operation_name) do
+    %{
+      platform: get_platform(socket),
+      session_id: get_session_id(socket),
+      client_app_version: get_client_app_version(socket),
+      user_id: get_user_id(socket),
+      id: id,
+      operation_name: operation_name
+    }
+  end
+
+  defp unsubscribe_topic_with_telemetry(socket, topic, id, operation_name) do
+    memory_before = process_memory()
+    message_queue_len_before = process_message_queue_len()
+    subscription_metrics = subscription_metrics_before(socket, topic)
+
+    start_metadata =
+      socket
+      |> operation_metadata(id, operation_name)
+      |> Map.merge(subscription_metrics)
+      |> Map.merge(%{
+        memory_before: memory_before,
+        message_queue_len_before: message_queue_len_before
+      })
+
+    :telemetry.span([:absinthe_graphql_ws, :handle_inbound, :complete], start_metadata, fn ->
+      unsubscribe_topic(socket, topic)
+
+      memory_after = process_memory()
+      message_queue_len_after = process_message_queue_len()
+
+      stop_metadata =
+        start_metadata
+        |> Map.merge(%{
+          memory_after: memory_after,
+          memory_delta: memory_after - memory_before,
+          message_queue_len_after: message_queue_len_after
+        })
+
+      {:ok, stop_metadata}
+    end)
+  end
+
   defp unsubscribe_topic(socket, topic) do
     Phoenix.PubSub.unsubscribe(socket.pubsub, topic)
     Absinthe.Subscription.unsubscribe(socket.endpoint, topic)
+  end
+
+  defp subscription_metrics_before(socket, topic) do
+    registry = Absinthe.Subscription.registry_name(socket.endpoint)
+    pid = self()
+
+    %{
+      field_keys_unregistered: registry |> Registry.lookup({pid, topic}) |> length(),
+      socket_subscription_count: map_size(socket.subscriptions),
+      pdict_subscription_count: count_process_subscription_docs(registry, pid),
+      subscription_field_key_count: count_subscription_field_keys(registry, pid, socket.subscriptions)
+    }
+  end
+
+  defp count_process_subscription_docs(registry, pid) do
+    match_spec = [{{{:"$1", :"$2"}, :_, :_}, [{:==, :"$1", pid}], [:"$2"]}]
+
+    registry
+    |> Registry.select(match_spec)
+    |> length()
+  end
+
+  defp count_subscription_field_keys(registry, pid, subscriptions) do
+    subscriptions
+    |> Map.keys()
+    |> Enum.map(fn doc_id ->
+      registry |> Registry.lookup({pid, doc_id}) |> length()
+    end)
+    |> Enum.sum()
+  end
+
+  defp process_memory do
+    {:memory, memory} = Process.info(self(), :memory)
+    memory
+  end
+
+  defp process_message_queue_len do
+    {:message_queue_len, message_queue_len} = Process.info(self(), :message_queue_len)
+    message_queue_len
   end
 
   defp close(code, message, socket) do

--- a/lib/absinthe/graphql_ws/transport.ex
+++ b/lib/absinthe/graphql_ws/transport.ex
@@ -232,6 +232,7 @@ defmodule Absinthe.GraphqlWS.Transport do
       {:ok, topic, operation_name} ->
         debug("unsubscribing from topic #{topic}")
         unsubscribe_topic_with_telemetry(socket, topic, id, operation_name)
+        emit_complete_success(socket, id, operation_name)
 
         {:ok, %{socket | subscriptions: Map.delete(socket.subscriptions, topic)}}
 
@@ -311,6 +312,16 @@ defmodule Absinthe.GraphqlWS.Transport do
     emit_operation_telemetry([:absinthe_graphql_ws, :handle_inbound, :subscribe], socket, id, operation_name)
   end
 
+  defp emit_complete_success(socket, id, operation_name) do
+    emit_operation_telemetry(
+      [:absinthe_graphql_ws, :handle_inbound, :complete],
+      socket,
+      id,
+      operation_name,
+      %{socket_subscription_count: map_size(socket.subscriptions)}
+    )
+  end
+
   defp emit_terminate_telemetry(socket, reason) do
     subscriptions =
       Enum.map(socket.subscriptions, fn {topic, _} ->
@@ -355,13 +366,13 @@ defmodule Absinthe.GraphqlWS.Transport do
   defp unsubscribe_topic_with_telemetry(socket, topic, id, operation_name) do
     memory_before = process_memory()
     message_queue_len_before = process_message_queue_len()
-    subscription_metrics = subscription_metrics_before(socket, topic)
+    socket_subscription_count = map_size(socket.subscriptions)
 
     start_metadata =
       socket
       |> operation_metadata(id, operation_name)
-      |> Map.merge(subscription_metrics)
       |> Map.merge(%{
+        socket_subscription_count: socket_subscription_count,
         memory_before: memory_before,
         message_queue_len_before: message_queue_len_before
       })
@@ -387,35 +398,6 @@ defmodule Absinthe.GraphqlWS.Transport do
   defp unsubscribe_topic(socket, topic) do
     Phoenix.PubSub.unsubscribe(socket.pubsub, topic)
     Absinthe.Subscription.unsubscribe(socket.endpoint, topic)
-  end
-
-  defp subscription_metrics_before(socket, topic) do
-    registry = Absinthe.Subscription.registry_name(socket.endpoint)
-    pid = self()
-
-    %{
-      field_keys_unregistered: registry |> Registry.lookup({pid, topic}) |> length(),
-      socket_subscription_count: map_size(socket.subscriptions),
-      pdict_subscription_count: count_process_subscription_docs(registry, pid),
-      subscription_field_key_count: count_subscription_field_keys(registry, pid, socket.subscriptions)
-    }
-  end
-
-  defp count_process_subscription_docs(registry, pid) do
-    match_spec = [{{{:"$1", :"$2"}, :_, :_}, [{:==, :"$1", pid}], [:"$2"]}]
-
-    registry
-    |> Registry.select(match_spec)
-    |> length()
-  end
-
-  defp count_subscription_field_keys(registry, pid, subscriptions) do
-    subscriptions
-    |> Map.keys()
-    |> Enum.map(fn doc_id ->
-      registry |> Registry.lookup({pid, doc_id}) |> length()
-    end)
-    |> Enum.sum()
   end
 
   defp process_memory do

--- a/test/integration/complete_telemetry_test.exs
+++ b/test/integration/complete_telemetry_test.exs
@@ -1,0 +1,91 @@
+defmodule Absinthe.GraphqlWS.CompleteTelemetryTest do
+  use ExUnit.Case
+
+  @handler_id {__MODULE__, :complete_span}
+
+  setup context do
+    events = [
+      [:absinthe_graphql_ws, :handle_inbound, :complete, :start],
+      [:absinthe_graphql_ws, :handle_inbound, :complete, :stop]
+    ]
+
+    parent = self()
+
+    :ok =
+      :telemetry.attach_many(
+        @handler_id,
+        events,
+        fn event, measurements, metadata, _config ->
+          send(parent, {:telemetry, event, measurements, metadata})
+        end,
+        nil
+      )
+
+    on_exit(fn -> :telemetry.detach(@handler_id) end)
+
+    assert {:ok, client} = Test.Client.start()
+    on_exit(fn -> Test.Client.close(client) end)
+
+    :ok = Test.Client.push(client, %{type: "connection_init"})
+    assert {:ok, [{:text, _}]} = Test.Client.get_new_replies(client)
+
+    Map.merge(context, %{client: client})
+  end
+
+  test "emits a telemetry span around unsubscribe with process and subscription metrics", %{
+    client: client
+  } do
+    id = "subscription-to-unsubscribe"
+
+    :ok =
+      Test.Client.push(client, %{
+        id: id,
+        type: "subscribe",
+        payload: %{
+          query: """
+          subscription ThingChanges($id: Int!) {
+            thing_changes(id: $id) {
+              id
+              name
+            }
+          }
+          """,
+          variables: %{id: 2}
+        }
+      })
+
+    assert {:ok, []} = Test.Client.get_new_replies(client)
+
+    :ok = Test.Client.push(client, %{id: id, type: "complete"})
+
+    assert_receive {:telemetry, [:absinthe_graphql_ws, :handle_inbound, :complete, :start], start_measurements,
+                    start_metadata}
+
+    assert Map.has_key?(start_measurements, :monotonic_time)
+    assert Map.has_key?(start_measurements, :system_time)
+
+    assert start_metadata.id == id
+    assert start_metadata.socket_subscription_count == 1
+    assert start_metadata.pdict_subscription_count == 1
+    assert start_metadata.field_keys_unregistered == 1
+    assert start_metadata.subscription_field_key_count == 1
+    assert is_integer(start_metadata.memory_before)
+    assert is_integer(start_metadata.message_queue_len_before)
+
+    assert_receive {:telemetry, [:absinthe_graphql_ws, :handle_inbound, :complete, :stop], stop_measurements,
+                    stop_metadata}
+
+    assert Map.has_key?(stop_measurements, :duration)
+    assert is_integer(stop_measurements.duration)
+
+    assert stop_metadata.id == id
+    assert stop_metadata.socket_subscription_count == 1
+    assert stop_metadata.field_keys_unregistered == 1
+    assert is_integer(stop_metadata.memory_before)
+    assert is_integer(stop_metadata.memory_after)
+    assert is_integer(stop_metadata.memory_delta)
+    assert stop_metadata.memory_delta == stop_metadata.memory_after - stop_metadata.memory_before
+    assert is_integer(stop_metadata.message_queue_len_before)
+    assert is_integer(stop_metadata.message_queue_len_after)
+  end
+end

--- a/test/integration/complete_telemetry_test.exs
+++ b/test/integration/complete_telemetry_test.exs
@@ -68,8 +68,7 @@ defmodule Absinthe.GraphqlWS.CompleteTelemetryTest do
 
     :ok = Test.Client.push(client, %{id: id, type: "complete"})
 
-    assert_receive {:telemetry, :span, [:absinthe_graphql_ws, :handle_inbound, :complete, :start], start_measurements,
-                    start_metadata}
+    assert_receive {:telemetry, :span, [:absinthe_graphql_ws, :handle_inbound, :complete, :start], start_measurements, start_metadata}
 
     assert Map.has_key?(start_measurements, :monotonic_time)
     assert Map.has_key?(start_measurements, :system_time)
@@ -79,8 +78,7 @@ defmodule Absinthe.GraphqlWS.CompleteTelemetryTest do
     assert is_integer(start_metadata.memory_before)
     assert is_integer(start_metadata.message_queue_len_before)
 
-    assert_receive {:telemetry, :span, [:absinthe_graphql_ws, :handle_inbound, :complete, :stop], stop_measurements,
-                    stop_metadata}
+    assert_receive {:telemetry, :span, [:absinthe_graphql_ws, :handle_inbound, :complete, :stop], stop_measurements, stop_metadata}
 
     assert Map.has_key?(stop_measurements, :duration)
     assert is_integer(stop_measurements.duration)
@@ -94,8 +92,7 @@ defmodule Absinthe.GraphqlWS.CompleteTelemetryTest do
     assert is_integer(stop_metadata.message_queue_len_before)
     assert is_integer(stop_metadata.message_queue_len_after)
 
-    assert_receive {:telemetry, :execute, [:absinthe_graphql_ws, :handle_inbound, :complete], execute_measurements,
-                    execute_metadata}
+    assert_receive {:telemetry, :execute, [:absinthe_graphql_ws, :handle_inbound, :complete], execute_measurements, execute_metadata}
 
     assert execute_measurements == %{}
     assert execute_metadata.id == id

--- a/test/integration/complete_telemetry_test.exs
+++ b/test/integration/complete_telemetry_test.exs
@@ -1,27 +1,39 @@
 defmodule Absinthe.GraphqlWS.CompleteTelemetryTest do
   use ExUnit.Case
 
-  @handler_id {__MODULE__, :complete_span}
+  @span_handler_id {__MODULE__, :complete_span}
+  @execute_handler_id {__MODULE__, :complete_execute}
 
   setup context do
-    events = [
-      [:absinthe_graphql_ws, :handle_inbound, :complete, :start],
-      [:absinthe_graphql_ws, :handle_inbound, :complete, :stop]
-    ]
-
     parent = self()
 
     :ok =
       :telemetry.attach_many(
-        @handler_id,
-        events,
+        @span_handler_id,
+        [
+          [:absinthe_graphql_ws, :handle_inbound, :complete, :start],
+          [:absinthe_graphql_ws, :handle_inbound, :complete, :stop]
+        ],
         fn event, measurements, metadata, _config ->
-          send(parent, {:telemetry, event, measurements, metadata})
+          send(parent, {:telemetry, :span, event, measurements, metadata})
         end,
         nil
       )
 
-    on_exit(fn -> :telemetry.detach(@handler_id) end)
+    :ok =
+      :telemetry.attach(
+        @execute_handler_id,
+        [:absinthe_graphql_ws, :handle_inbound, :complete],
+        fn event, measurements, metadata, _config ->
+          send(parent, {:telemetry, :execute, event, measurements, metadata})
+        end,
+        nil
+      )
+
+    on_exit(fn ->
+      :telemetry.detach(@span_handler_id)
+      :telemetry.detach(@execute_handler_id)
+    end)
 
     assert {:ok, client} = Test.Client.start()
     on_exit(fn -> Test.Client.close(client) end)
@@ -32,9 +44,7 @@ defmodule Absinthe.GraphqlWS.CompleteTelemetryTest do
     Map.merge(context, %{client: client})
   end
 
-  test "emits a telemetry span around unsubscribe with process and subscription metrics", %{
-    client: client
-  } do
+  test "emits a performance span and lifecycle execute around unsubscribe", %{client: client} do
     id = "subscription-to-unsubscribe"
 
     :ok =
@@ -58,7 +68,7 @@ defmodule Absinthe.GraphqlWS.CompleteTelemetryTest do
 
     :ok = Test.Client.push(client, %{id: id, type: "complete"})
 
-    assert_receive {:telemetry, [:absinthe_graphql_ws, :handle_inbound, :complete, :start], start_measurements,
+    assert_receive {:telemetry, :span, [:absinthe_graphql_ws, :handle_inbound, :complete, :start], start_measurements,
                     start_metadata}
 
     assert Map.has_key?(start_measurements, :monotonic_time)
@@ -66,13 +76,10 @@ defmodule Absinthe.GraphqlWS.CompleteTelemetryTest do
 
     assert start_metadata.id == id
     assert start_metadata.socket_subscription_count == 1
-    assert start_metadata.pdict_subscription_count == 1
-    assert start_metadata.field_keys_unregistered == 1
-    assert start_metadata.subscription_field_key_count == 1
     assert is_integer(start_metadata.memory_before)
     assert is_integer(start_metadata.message_queue_len_before)
 
-    assert_receive {:telemetry, [:absinthe_graphql_ws, :handle_inbound, :complete, :stop], stop_measurements,
+    assert_receive {:telemetry, :span, [:absinthe_graphql_ws, :handle_inbound, :complete, :stop], stop_measurements,
                     stop_metadata}
 
     assert Map.has_key?(stop_measurements, :duration)
@@ -80,12 +87,18 @@ defmodule Absinthe.GraphqlWS.CompleteTelemetryTest do
 
     assert stop_metadata.id == id
     assert stop_metadata.socket_subscription_count == 1
-    assert stop_metadata.field_keys_unregistered == 1
     assert is_integer(stop_metadata.memory_before)
     assert is_integer(stop_metadata.memory_after)
     assert is_integer(stop_metadata.memory_delta)
     assert stop_metadata.memory_delta == stop_metadata.memory_after - stop_metadata.memory_before
     assert is_integer(stop_metadata.message_queue_len_before)
     assert is_integer(stop_metadata.message_queue_len_after)
+
+    assert_receive {:telemetry, :execute, [:absinthe_graphql_ws, :handle_inbound, :complete], execute_measurements,
+                    execute_metadata}
+
+    assert execute_measurements == %{}
+    assert execute_metadata.id == id
+    assert execute_metadata.socket_subscription_count == 1
   end
 end


### PR DESCRIPTION
## Summary

Adds performance telemetry around GraphQL WebSocket unsubscribe to support [PLA-1409](https://linear.app/fanaticscollect/issue/PLA-1409) (OOM during `Registry.unregister_match` with `message_queue_len: 23651`).

Main already emits a lifecycle `:telemetry.execute` on `[:absinthe_graphql_ws, :handle_inbound, :complete]` (PLA-1411). This PR **adds** a span around the unsubscribe work and **keeps** the execute event for PLA-1412 compatibility.

Intentionally omitted: Absinthe Registry introspection (`field_keys_unregistered`, `pdict_subscription_count`, etc.) — those depend on Absinthe internals and belong in [PLA-1415](https://linear.app/fanaticscollect/issue/PLA-1415) if still needed.

## Events

### `[:absinthe_graphql_ws, :handle_inbound, :complete, :start]` / `:stop` (new)

`:telemetry.span/3` wraps `unsubscribe_topic/2` (Phoenix PubSub + `Absinthe.Subscription.unsubscribe/2`).

**Measurements on `:stop`:**
| Field | Helps with |
|-------|------------|
| `duration` | Detect slow unsubscribes — PLA-1409 process was stuck in `Registry.unregister_match` / `:ets.select_delete_trap` |

**Metadata (sampled before unsubscribe, updated on `:stop`):**
| Field | Helps with |
|-------|------------|
| `platform` | Segment by client platform (iOS, Android, web) when correlating incidents |
| `session_id` | Tie a slow unsubscribe back to a specific client session |
| `client_app_version` | Spot version-specific regressions in subscription behavior |
| `user_id` | Identify whether heavy connections cluster on specific accounts |
| `id` | GraphQL-WS subscription id for the `complete` message |
| `operation_name` | Low-cardinality operation label for grouping unsubscribe latency |
| `socket_subscription_count` | How many active subs this connection had at unsubscribe time — correlates load with slow/OOM paths |
| `memory_before` | Process heap size entering unsubscribe — PLA-1409 hit ~19 GB |
| `memory_after` | Heap size after unsubscribe completes |
| `memory_delta` | How much memory unsubscribe allocated/freed — spike here suggests expensive Registry/ETS work |
| `message_queue_len_before` | Mailbox depth before unsubscribe — PLA-1409 had 23,651 queued messages |
| `message_queue_len_after` | Whether the process was still backed up after unsubscribe finished |

### `[:absinthe_graphql_ws, :handle_inbound, :complete]` (kept)

`:telemetry.execute` fires after the span, same as PLA-1411. Used by PLA-1412 for Datadog lifecycle counters.

**Metadata:**
| Field | Helps with |
|-------|------------|
| `platform`, `session_id`, `client_app_version`, `user_id`, `id`, `operation_name` | Same as above — lifecycle attribution |
| `socket_subscription_count` | Sub count at complete time (before socket map cleanup) |

## Follow-up (live-api)

- Attach handler to `[:absinthe_graphql_ws, :handle_inbound, :complete, :stop]` for histograms: `graphql.ws.unsubscribe.duration`, `.memory_delta`, `.message_queue_len`
- Keep existing PLA-1412 handler on bare `[:absinthe_graphql_ws, :handle_inbound, :complete]` for counters
- Sampled warn log when thresholds exceeded (e.g. duration > 100ms, memory_delta > 50MB, mql > 1000)

## Test plan

- [x] `mix test test/integration/complete_telemetry_test.exs`
- [x] `mix test` (27 tests, 0 failures)