### PR TITLE
chore(PLA-1445): consolidate fan.graphql.ws lifecycle telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,77 @@ An example of handle_info
   end
 ```
 
+## Telemetry
+
+All events are emitted via `:telemetry` from `Absinthe.GraphqlWS.Transport`. Attach handlers with `:telemetry.attach/4` or `:telemetry.attach_many/4`.
+
+**Convention:** numeric load signals belong in **measurements**; dimensions belong in **metadata**. Several lifecycle events include `socket_subscription_count` in measurements so consumers can build per-socket subscription load distributions without high-cardinality tags.
+
+### Shared metadata
+
+Most events include some or all of these socket fields (from `socket.assigns`):
+
+| Field | Source |
+| --- | --- |
+| `platform` | `socket.assigns[:platform]` (defaults to `"unknown"`) |
+| `session_id` | `socket.assigns[:session_id]` |
+| `client_app_version` | `socket.assigns[:client_app_version]` |
+| `user_id` | `socket.assigns[:user_id]` |
+
+Operation-scoped events also include `id` (GraphQL-WS message id) and `operation_name`.
+
+### Transport lifecycle
+
+| Event | When | Measurements | Metadata |
+| --- | --- | --- | --- |
+| `[:absinthe_graphql_ws, :transport, :init]` | WebSocket upgrade (`Transport.init/1`) | — | Shared socket metadata |
+| `[:absinthe_graphql_ws, :transport, :terminate]` | Socket process shutdown (`Transport.terminate/2`) | `socket_subscription_count` | Shared socket metadata, `reason`, `subscriptions` (list of `%{id, operation_name}`; `[]` on clean close) |
+
+### `handle_inbound` (client JSON frames)
+
+| Event | When | Measurements | Metadata |
+| --- | --- | --- | --- |
+| `[:absinthe_graphql_ws, :handle_inbound, :connection_init]` | Successful `connection_init` | `socket_subscription_count` (`0`) | Shared socket metadata, `auth_status` |
+| `[:absinthe_graphql_ws, :handle_inbound, :subscribe]` | Subscription registered (or query/mutation `next` reply) | `socket_subscription_count` | Operation metadata |
+| `[:absinthe_graphql_ws, :handle_inbound, :complete]` | Client `complete` frame (lifecycle counter) | `socket_subscription_count` | Operation metadata |
+| `[:absinthe_graphql_ws, :handle_inbound, :complete, :start]` | Start of unsubscribe work (span) | `monotonic_time`, `system_time` | Operation metadata, `memory_before`, `message_queue_len_before` |
+| `[:absinthe_graphql_ws, :handle_inbound, :complete, :stop]` | End of unsubscribe work (span) | `duration` | Span start metadata plus `memory_after`, `memory_delta`, `message_queue_len_after` |
+| `[:absinthe_graphql_ws, :handle_inbound, :ping]` | Client `ping` frame | `payload_size`, `socket_subscription_count` | Shared socket metadata |
+| `[:absinthe_graphql_ws, :handle_inbound, :error]` | Protocol error before close (e.g. duplicate init, subscribe before init) | — | Shared socket metadata, `code`, `operation`, `reason` |
+
+### `handle_info` (internal messages)
+
+| Event | When | Measurements | Metadata |
+| --- | --- | --- | --- |
+| `[:absinthe_graphql_ws, :handle_info, :broadcast]` | Subscription publish to client | `payload_size` | Shared socket metadata, `payload`, `operation_name` |
+
+### Keepalive (server-side control frames)
+
+| Event | When | Measurements | Metadata |
+| --- | --- | --- | --- |
+| `[:absinthe_graphql_ws, :keepalive, :start]` | Outbound `:ping` scheduled | `system_time` | — |
+| `[:absinthe_graphql_ws, :keepalive, :stop]` | Inbound `:pong` received | `duration` | — |
+
+### Garbage collection (optional, when `gc_interval` assign is set)
+
+| Event | When | Measurements | Metadata |
+| --- | --- | --- | --- |
+| `[:absinthe_graphql_ws, :gc, :start]` | GC span start | `monotonic_time`, `system_time` | `before` (process info map) |
+| `[:absinthe_graphql_ws, :gc, :stop]` | GC span stop | `duration` | `before`, `after` (process info maps) |
+
+### Example
+
+```elixir
+:telemetry.attach(
+  "absinthe-graphql-ws-transport-init",
+  [:absinthe_graphql_ws, :transport, :init],
+  fn _event, measurements, metadata, _config ->
+    # increment counter, tag with metadata.platform, etc.
+  end,
+  nil
+)
+```
+
 ## Benchmarks
 
 Benchmarks live in the `benchmarks` directory, and can be run with `MIX_ENV=bench mix run

--- a/README.md
+++ b/README.md
@@ -110,60 +110,69 @@ An example of handle_info
 
 ## Telemetry
 
-All events are emitted via `:telemetry` from `Absinthe.GraphqlWS.Transport`. Attach handlers with `:telemetry.attach/4` or `:telemetry.attach_many/4`.
+All events are emitted via `:telemetry` from `Absinthe.GraphqlWS.Transport`. Attach handlers with
+`:telemetry.attach/4` or `:telemetry.attach_many/4`.
 
-**Convention:** numeric load signals belong in **measurements**; dimensions belong in **metadata**. Several lifecycle events include `socket_subscription_count` in measurements so consumers can build per-socket subscription load distributions without high-cardinality tags.
+**Convention:** numeric load signals belong in **measurements**; dimensions belong in **metadata**.
+Several lifecycle events include `socket_subscription_count` in measurements so consumers can build
+per-socket subscription load distributions without high-cardinality tags.
 
 ### Shared metadata
 
 Most events include some or all of these socket fields (from `socket.assigns`):
 
-| Field | Source |
-| --- | --- |
-| `platform` | `socket.assigns[:platform]` (defaults to `"unknown"`) |
-| `session_id` | `socket.assigns[:session_id]` |
-| `client_app_version` | `socket.assigns[:client_app_version]` |
-| `user_id` | `socket.assigns[:user_id]` |
+- `platform` — `socket.assigns[:platform]` (defaults to `"unknown"`)
+- `session_id` — `socket.assigns[:session_id]`
+- `client_app_version` — `socket.assigns[:client_app_version]`
+- `user_id` — `socket.assigns[:user_id]`
 
 Operation-scoped events also include `id` (GraphQL-WS message id) and `operation_name`.
 
 ### Transport lifecycle
 
-| Event | When | Measurements | Metadata |
-| --- | --- | --- | --- |
-| `[:absinthe_graphql_ws, :transport, :init]` | WebSocket upgrade (`Transport.init/1`) | — | Shared socket metadata |
-| `[:absinthe_graphql_ws, :transport, :terminate]` | Socket process shutdown (`Transport.terminate/2`) | `socket_subscription_count` | Shared socket metadata, `reason`, `subscriptions` (list of `%{id, operation_name}`; `[]` on clean close) |
+- `[:absinthe_graphql_ws, :transport, :init]` — WebSocket upgrade (`Transport.init/1`). Measurements:
+  none. Metadata: shared socket metadata.
+- `[:absinthe_graphql_ws, :transport, :terminate]` — Socket process shutdown
+  (`Transport.terminate/2`). Measurements: `socket_subscription_count`. Metadata: shared socket
+  metadata, `reason`, `subscriptions` (list of `%{id, operation_name}`; `[]` on clean close).
 
 ### `handle_inbound` (client JSON frames)
 
-| Event | When | Measurements | Metadata |
-| --- | --- | --- | --- |
-| `[:absinthe_graphql_ws, :handle_inbound, :connection_init]` | Successful `connection_init` | `socket_subscription_count` (`0`) | Shared socket metadata, `auth_status` |
-| `[:absinthe_graphql_ws, :handle_inbound, :subscribe]` | Subscription registered (or query/mutation `next` reply) | `socket_subscription_count` | Operation metadata |
-| `[:absinthe_graphql_ws, :handle_inbound, :complete, :start]` | Client `complete` frame — start of unsubscribe | `monotonic_time`, `system_time` | Operation metadata, `memory_before`, `message_queue_len_before` |
-| `[:absinthe_graphql_ws, :handle_inbound, :complete, :stop]` | Client `complete` frame — end of unsubscribe (lifecycle counter attaches here) | `duration`, `monotonic_time`, `socket_subscription_count` | Span start metadata plus `memory_after`, `memory_delta`, `message_queue_len_after` |
-| `[:absinthe_graphql_ws, :handle_inbound, :ping]` | Client `ping` frame | `payload_size`, `socket_subscription_count` | Shared socket metadata |
-| `[:absinthe_graphql_ws, :handle_inbound, :error]` | Protocol error before close (e.g. duplicate init, subscribe before init) | — | Shared socket metadata, `code`, `operation`, `reason` |
+- `[:absinthe_graphql_ws, :handle_inbound, :connection_init]` — Successful `connection_init`.
+  Measurements: `socket_subscription_count` (`0`). Metadata: shared socket metadata, `auth_status`.
+- `[:absinthe_graphql_ws, :handle_inbound, :subscribe]` — Subscription registered (or query/mutation
+  `next` reply). Measurements: `socket_subscription_count`. Metadata: operation metadata.
+- `[:absinthe_graphql_ws, :handle_inbound, :complete, :start]` — Client `complete` frame; start of
+  unsubscribe. Measurements: `monotonic_time`, `system_time`. Metadata: operation metadata,
+  `memory_before`, `message_queue_len_before`.
+- `[:absinthe_graphql_ws, :handle_inbound, :complete, :stop]` — Client `complete` frame; end of
+  unsubscribe (lifecycle counter attaches here). Measurements: `duration`, `monotonic_time`,
+  `socket_subscription_count`. Metadata: span start metadata plus `memory_after`, `memory_delta`,
+  `message_queue_len_after`.
+- `[:absinthe_graphql_ws, :handle_inbound, :ping]` — Client `ping` frame. Measurements:
+  `payload_size`, `socket_subscription_count`. Metadata: shared socket metadata.
+- `[:absinthe_graphql_ws, :handle_inbound, :error]` — Protocol error before close (e.g. duplicate
+  init, subscribe before init). Measurements: none. Metadata: shared socket metadata, `code`,
+  `operation`, `reason`.
 
 ### `handle_info` (internal messages)
 
-| Event | When | Measurements | Metadata |
-| --- | --- | --- | --- |
-| `[:absinthe_graphql_ws, :handle_info, :broadcast]` | Subscription publish to client | `payload_size` | Shared socket metadata, `payload`, `operation_name` |
+- `[:absinthe_graphql_ws, :handle_info, :broadcast]` — Subscription publish to client. Measurements:
+  `payload_size`. Metadata: shared socket metadata, `payload`, `operation_name`.
 
 ### Keepalive (server-side control frames)
 
-| Event | When | Measurements | Metadata |
-| --- | --- | --- | --- |
-| `[:absinthe_graphql_ws, :keepalive, :start]` | Outbound `:ping` scheduled | `system_time` | — |
-| `[:absinthe_graphql_ws, :keepalive, :stop]` | Inbound `:pong` received | `duration` | — |
+- `[:absinthe_graphql_ws, :keepalive, :start]` — Outbound `:ping` scheduled. Measurements:
+  `system_time`. Metadata: none.
+- `[:absinthe_graphql_ws, :keepalive, :stop]` — Inbound `:pong` received. Measurements: `duration`.
+  Metadata: none.
 
 ### Garbage collection (optional, when `gc_interval` assign is set)
 
-| Event | When | Measurements | Metadata |
-| --- | --- | --- | --- |
-| `[:absinthe_graphql_ws, :gc, :start]` | GC span start | `monotonic_time`, `system_time` | `before` (process info map) |
-| `[:absinthe_graphql_ws, :gc, :stop]` | GC span stop | `duration` | `before`, `after` (process info maps) |
+- `[:absinthe_graphql_ws, :gc, :start]` — GC span start. Measurements: `monotonic_time`,
+  `system_time`. Metadata: `before` (process info map).
+- `[:absinthe_graphql_ws, :gc, :stop]` — GC span stop. Measurements: `duration`. Metadata: `before`,
+  `after` (process info maps).
 
 ### Example
 

--- a/README.md
+++ b/README.md
@@ -140,9 +140,8 @@ Operation-scoped events also include `id` (GraphQL-WS message id) and `operation
 | --- | --- | --- | --- |
 | `[:absinthe_graphql_ws, :handle_inbound, :connection_init]` | Successful `connection_init` | `socket_subscription_count` (`0`) | Shared socket metadata, `auth_status` |
 | `[:absinthe_graphql_ws, :handle_inbound, :subscribe]` | Subscription registered (or query/mutation `next` reply) | `socket_subscription_count` | Operation metadata |
-| `[:absinthe_graphql_ws, :handle_inbound, :complete]` | Client `complete` frame (lifecycle counter) | `socket_subscription_count` | Operation metadata |
-| `[:absinthe_graphql_ws, :handle_inbound, :complete, :start]` | Start of unsubscribe work (span) | `monotonic_time`, `system_time` | Operation metadata, `memory_before`, `message_queue_len_before` |
-| `[:absinthe_graphql_ws, :handle_inbound, :complete, :stop]` | End of unsubscribe work (span) | `duration` | Span start metadata plus `memory_after`, `memory_delta`, `message_queue_len_after` |
+| `[:absinthe_graphql_ws, :handle_inbound, :complete, :start]` | Client `complete` frame — start of unsubscribe | `monotonic_time`, `system_time` | Operation metadata, `memory_before`, `message_queue_len_before` |
+| `[:absinthe_graphql_ws, :handle_inbound, :complete, :stop]` | Client `complete` frame — end of unsubscribe (lifecycle counter attaches here) | `duration`, `monotonic_time`, `socket_subscription_count` | Span start metadata plus `memory_after`, `memory_delta`, `message_queue_len_after` |
 | `[:absinthe_graphql_ws, :handle_inbound, :ping]` | Client `ping` frame | `payload_size`, `socket_subscription_count` | Shared socket metadata |
 | `[:absinthe_graphql_ws, :handle_inbound, :error]` | Protocol error before close (e.g. duplicate init, subscribe before init) | — | Shared socket metadata, `code`, `operation`, `reason` |
 

--- a/lib/absinthe/graphql_ws/socket.ex
+++ b/lib/absinthe/graphql_ws/socket.ex
@@ -238,23 +238,7 @@ defmodule Absinthe.GraphqlWS.Socket do
 
       @doc false
       @impl Phoenix.Socket.Transport
-      def init(socket) do
-        :telemetry.execute(
-          [:absinthe_graphql_ws, :transport, :init],
-          %{},
-          %{
-            platform: socket.assigns[:platform] || "unknown",
-            session_id: socket.assigns[:session_id],
-            client_app_version: socket.assigns[:client_app_version],
-            user_id: socket.assigns[:user_id]
-          }
-        )
-
-        if socket.keepalive > 0,
-          do: Process.send_after(self(), :keepalive, socket.keepalive)
-
-        {:ok, socket}
-      end
+      def init(socket), do: Absinthe.GraphqlWS.Transport.init(socket)
 
       @doc false
       @impl Phoenix.Socket.Transport

--- a/lib/absinthe/graphql_ws/socket.ex
+++ b/lib/absinthe/graphql_ws/socket.ex
@@ -239,7 +239,16 @@ defmodule Absinthe.GraphqlWS.Socket do
       @doc false
       @impl Phoenix.Socket.Transport
       def init(socket) do
-        :ok = Absinthe.GraphqlWS.Transport.emit_transport_init(socket)
+        :telemetry.execute(
+          [:absinthe_graphql_ws, :transport, :init],
+          %{},
+          %{
+            platform: socket.assigns[:platform] || "unknown",
+            session_id: socket.assigns[:session_id],
+            client_app_version: socket.assigns[:client_app_version],
+            user_id: socket.assigns[:user_id]
+          }
+        )
 
         if socket.keepalive > 0,
           do: Process.send_after(self(), :keepalive, socket.keepalive)

--- a/lib/absinthe/graphql_ws/socket.ex
+++ b/lib/absinthe/graphql_ws/socket.ex
@@ -239,6 +239,8 @@ defmodule Absinthe.GraphqlWS.Socket do
       @doc false
       @impl Phoenix.Socket.Transport
       def init(socket) do
+        :ok = Absinthe.GraphqlWS.Transport.emit_transport_init(socket)
+
         if socket.keepalive > 0,
           do: Process.send_after(self(), :keepalive, socket.keepalive)
 

--- a/lib/absinthe/graphql_ws/transport.ex
+++ b/lib/absinthe/graphql_ws/transport.ex
@@ -168,7 +168,8 @@ defmodule Absinthe.GraphqlWS.Transport do
       end)
 
     metadata =
-      socket_metadata(socket)
+      socket
+      |> socket_metadata()
       |> Map.merge(%{reason: reason, subscriptions: subscriptions})
 
     measurements = %{socket_subscription_count: map_size(socket.subscriptions)}
@@ -361,7 +362,7 @@ defmodule Absinthe.GraphqlWS.Transport do
     )
   end
 
-  defp emit_operation_telemetry(event, socket, id, operation_name, opts \\ []) do
+  defp emit_operation_telemetry(event, socket, id, operation_name, opts) do
     extra_metadata = Keyword.get(opts, :metadata, %{})
     measurements = Keyword.get(opts, :measurements, %{})
 

--- a/lib/absinthe/graphql_ws/transport.ex
+++ b/lib/absinthe/graphql_ws/transport.ex
@@ -338,7 +338,7 @@ defmodule Absinthe.GraphqlWS.Transport do
       socket,
       id,
       operation_name,
-      metadata: %{socket_subscription_count: map_size(socket.subscriptions)}
+      measurements: %{socket_subscription_count: map_size(socket.subscriptions)}
     )
   end
 
@@ -393,13 +393,11 @@ defmodule Absinthe.GraphqlWS.Transport do
   defp unsubscribe_topic_with_telemetry(socket, topic, id, operation_name) do
     memory_before = process_memory()
     message_queue_len_before = process_message_queue_len()
-    socket_subscription_count = map_size(socket.subscriptions)
 
     start_metadata =
       socket
       |> operation_metadata(id, operation_name)
       |> Map.merge(%{
-        socket_subscription_count: socket_subscription_count,
         memory_before: memory_before,
         message_queue_len_before: message_queue_len_before
       })

--- a/lib/absinthe/graphql_ws/transport.ex
+++ b/lib/absinthe/graphql_ws/transport.ex
@@ -156,17 +156,7 @@ defmodule Absinthe.GraphqlWS.Transport do
   @spec terminate(term(), socket()) :: :ok
   def terminate(reason, socket) do
     debug("terminated: #{inspect(reason)}")
-
-    :telemetry.execute(
-      [:absinthe_graphql_ws, :transport, :terminate],
-      %{socket_subscription_count: map_size(socket.subscriptions)},
-      socket_metadata(socket) |> Map.put(:reason, reason)
-    )
-
-    if map_size(socket.subscriptions) > 0 do
-      emit_terminate_telemetry(socket, reason)
-    end
-
+    emit_terminate_telemetry(socket, reason)
     :ok
   end
 
@@ -362,18 +352,13 @@ defmodule Absinthe.GraphqlWS.Transport do
         %{id: id, operation_name: operation_name}
       end)
 
-    metadata = %{
-      platform: get_platform(socket),
-      session_id: get_session_id(socket),
-      client_app_version: get_client_app_version(socket),
-      user_id: get_user_id(socket),
-      reason: reason,
-      subscriptions: subscriptions
-    }
+    metadata =
+      socket_metadata(socket)
+      |> Map.merge(%{reason: reason, subscriptions: subscriptions})
 
-    measurements = %{subscription_count: length(subscriptions)}
+    measurements = %{socket_subscription_count: map_size(socket.subscriptions)}
 
-    :telemetry.execute([:absinthe_graphql_ws, :terminate, :complete], measurements, metadata)
+    :telemetry.execute([:absinthe_graphql_ws, :transport, :terminate], measurements, metadata)
   end
 
   defp emit_operation_telemetry(event, socket, id, operation_name, opts \\ []) do

--- a/lib/absinthe/graphql_ws/transport.ex
+++ b/lib/absinthe/graphql_ws/transport.ex
@@ -202,7 +202,6 @@ defmodule Absinthe.GraphqlWS.Transport do
       {:ok, topic, operation_name} ->
         debug("unsubscribing from topic #{topic}")
         unsubscribe_topic_with_telemetry(socket, topic, id, operation_name)
-        emit_complete_telemetry(socket, id, operation_name)
 
         {:ok, %{socket | subscriptions: Map.delete(socket.subscriptions, topic)}}
 
@@ -372,16 +371,6 @@ defmodule Absinthe.GraphqlWS.Transport do
     )
   end
 
-  defp emit_complete_telemetry(socket, id, operation_name) do
-    emit_operation_telemetry(
-      [:absinthe_graphql_ws, :handle_inbound, :complete],
-      socket,
-      id,
-      operation_name,
-      measurements: %{socket_subscription_count: map_size(socket.subscriptions)}
-    )
-  end
-
   defp emit_operation_telemetry(event, socket, id, operation_name, opts) do
     extra_metadata = Keyword.get(opts, :metadata, %{})
     measurements = Keyword.get(opts, :measurements, %{})
@@ -412,6 +401,9 @@ defmodule Absinthe.GraphqlWS.Transport do
   defp unsubscribe_topic_with_telemetry(socket, topic, id, operation_name) do
     memory_before = process_memory()
     message_queue_len_before = process_message_queue_len()
+    socket_subscription_count = map_size(socket.subscriptions)
+    start_mono = System.monotonic_time()
+    start_system_time = System.system_time()
 
     start_metadata =
       socket
@@ -421,22 +413,35 @@ defmodule Absinthe.GraphqlWS.Transport do
         message_queue_len_before: message_queue_len_before
       })
 
-    :telemetry.span([:absinthe_graphql_ws, :handle_inbound, :complete], start_metadata, fn ->
-      unsubscribe_topic(socket, topic)
+    :telemetry.execute(
+      [:absinthe_graphql_ws, :handle_inbound, :complete, :start],
+      %{monotonic_time: start_mono, system_time: start_system_time},
+      start_metadata
+    )
 
-      memory_after = process_memory()
-      message_queue_len_after = process_message_queue_len()
+    unsubscribe_topic(socket, topic)
 
-      stop_metadata =
-        start_metadata
-        |> Map.merge(%{
-          memory_after: memory_after,
-          memory_delta: memory_after - memory_before,
-          message_queue_len_after: message_queue_len_after
-        })
+    memory_after = process_memory()
+    message_queue_len_after = process_message_queue_len()
+    stop_mono = System.monotonic_time()
 
-      {:ok, stop_metadata}
-    end)
+    stop_metadata =
+      start_metadata
+      |> Map.merge(%{
+        memory_after: memory_after,
+        memory_delta: memory_after - memory_before,
+        message_queue_len_after: message_queue_len_after
+      })
+
+    :telemetry.execute(
+      [:absinthe_graphql_ws, :handle_inbound, :complete, :stop],
+      %{
+        duration: stop_mono - start_mono,
+        monotonic_time: stop_mono,
+        socket_subscription_count: socket_subscription_count
+      },
+      stop_metadata
+    )
   end
 
   defp unsubscribe_topic(socket, topic) do

--- a/lib/absinthe/graphql_ws/transport.ex
+++ b/lib/absinthe/graphql_ws/transport.ex
@@ -291,12 +291,12 @@ defmodule Absinthe.GraphqlWS.Transport do
     end
   end
 
-  defp tap_subscribe_success({:ok, _socket} = result, socket, id, operation_name) do
+  defp tap_subscribe_success({:ok, socket} = result, _socket, id, operation_name) do
     emit_subscribe_success(socket, id, operation_name)
     result
   end
 
-  defp tap_subscribe_success({:reply, :ok, {:text, message}, _socket} = result, socket, id, operation_name) do
+  defp tap_subscribe_success({:reply, :ok, {:text, message}, socket} = result, _socket, id, operation_name) do
     case Util.json_library().decode(message) do
       {:ok, %{"type" => "next"}} ->
         emit_subscribe_success(socket, id, operation_name)
@@ -323,7 +323,13 @@ defmodule Absinthe.GraphqlWS.Transport do
   end
 
   defp emit_subscribe_success(socket, id, operation_name) do
-    emit_operation_telemetry([:absinthe_graphql_ws, :handle_inbound, :subscribe], socket, id, operation_name)
+    emit_operation_telemetry(
+      [:absinthe_graphql_ws, :handle_inbound, :subscribe],
+      socket,
+      id,
+      operation_name,
+      measurements: %{socket_subscription_count: map_size(socket.subscriptions)}
+    )
   end
 
   defp emit_complete_success(socket, id, operation_name) do
@@ -332,7 +338,7 @@ defmodule Absinthe.GraphqlWS.Transport do
       socket,
       id,
       operation_name,
-      %{socket_subscription_count: map_size(socket.subscriptions)}
+      metadata: %{socket_subscription_count: map_size(socket.subscriptions)}
     )
   end
 
@@ -357,13 +363,16 @@ defmodule Absinthe.GraphqlWS.Transport do
     :telemetry.execute([:absinthe_graphql_ws, :terminate, :complete], measurements, metadata)
   end
 
-  defp emit_operation_telemetry(event, socket, id, operation_name, extra \\ %{}) do
+  defp emit_operation_telemetry(event, socket, id, operation_name, opts \\ []) do
+    extra_metadata = Keyword.get(opts, :metadata, %{})
+    measurements = Keyword.get(opts, :measurements, %{})
+
     metadata =
       socket
       |> operation_metadata(id, operation_name)
-      |> Map.merge(extra)
+      |> Map.merge(extra_metadata)
 
-    :telemetry.execute(event, %{}, metadata)
+    :telemetry.execute(event, measurements, metadata)
   end
 
   defp socket_metadata(socket) do

--- a/lib/absinthe/graphql_ws/transport.ex
+++ b/lib/absinthe/graphql_ws/transport.ex
@@ -157,10 +157,19 @@ defmodule Absinthe.GraphqlWS.Transport do
   def terminate(reason, socket) do
     debug("terminated: #{inspect(reason)}")
 
+    emit_transport_terminate_telemetry(socket, reason)
+
     if map_size(socket.subscriptions) > 0 do
       emit_terminate_telemetry(socket, reason)
     end
 
+    :ok
+  end
+
+  @doc false
+  @spec emit_transport_init(socket()) :: :ok
+  def emit_transport_init(socket) do
+    :telemetry.execute([:absinthe_graphql_ws, :transport, :init], %{}, socket_metadata(socket))
     :ok
   end
 
@@ -320,6 +329,16 @@ defmodule Absinthe.GraphqlWS.Transport do
       %{socket_subscription_count: 0},
       metadata
     )
+  end
+
+  defp emit_transport_terminate_telemetry(socket, reason) do
+    measurements = %{socket_subscription_count: map_size(socket.subscriptions)}
+
+    metadata =
+      socket_metadata(socket)
+      |> Map.put(:reason, reason)
+
+    :telemetry.execute([:absinthe_graphql_ws, :transport, :terminate], measurements, metadata)
   end
 
   defp emit_subscribe_success(socket, id, operation_name) do

--- a/lib/absinthe/graphql_ws/transport.ex
+++ b/lib/absinthe/graphql_ws/transport.ex
@@ -190,6 +190,7 @@ defmodule Absinthe.GraphqlWS.Transport do
         {:ok, payload, socket} ->
           socket = %{socket | initialized?: true}
           maybe_schedule_gc(socket)
+          emit_connection_init_telemetry(socket)
           {:reply, :ok, {:text, Message.ConnectionAck.new(payload)}, socket}
 
         {:error, payload, socket} ->
@@ -198,6 +199,7 @@ defmodule Absinthe.GraphqlWS.Transport do
     else
       socket = %{socket | initialized?: true}
       maybe_schedule_gc(socket)
+      emit_connection_init_telemetry(socket)
       {:reply, :ok, {:text, Message.ConnectionAck.new()}, socket}
     end
   end
@@ -308,6 +310,18 @@ defmodule Absinthe.GraphqlWS.Transport do
 
   defp tap_subscribe_success(result, _socket, _id, _operation_name), do: result
 
+  defp emit_connection_init_telemetry(socket) do
+    metadata =
+      socket_metadata(socket)
+      |> Map.put(:auth_status, socket.assigns[:auth_status])
+
+    :telemetry.execute(
+      [:absinthe_graphql_ws, :handle_inbound, :connection_init],
+      %{socket_subscription_count: 0},
+      metadata
+    )
+  end
+
   defp emit_subscribe_success(socket, id, operation_name) do
     emit_operation_telemetry([:absinthe_graphql_ws, :handle_inbound, :subscribe], socket, id, operation_name)
   end
@@ -352,15 +366,19 @@ defmodule Absinthe.GraphqlWS.Transport do
     :telemetry.execute(event, %{}, metadata)
   end
 
-  defp operation_metadata(socket, id, operation_name) do
+  defp socket_metadata(socket) do
     %{
       platform: get_platform(socket),
       session_id: get_session_id(socket),
       client_app_version: get_client_app_version(socket),
-      user_id: get_user_id(socket),
-      id: id,
-      operation_name: operation_name
+      user_id: get_user_id(socket)
     }
+  end
+
+  defp operation_metadata(socket, id, operation_name) do
+    socket
+    |> socket_metadata()
+    |> Map.merge(%{id: id, operation_name: operation_name})
   end
 
   defp unsubscribe_topic_with_telemetry(socket, topic, id, operation_name) do

--- a/lib/absinthe/graphql_ws/transport.ex
+++ b/lib/absinthe/graphql_ws/transport.ex
@@ -157,7 +157,11 @@ defmodule Absinthe.GraphqlWS.Transport do
   def terminate(reason, socket) do
     debug("terminated: #{inspect(reason)}")
 
-    emit_transport_terminate_telemetry(socket, reason)
+    :telemetry.execute(
+      [:absinthe_graphql_ws, :transport, :terminate],
+      %{socket_subscription_count: map_size(socket.subscriptions)},
+      socket_metadata(socket) |> Map.put(:reason, reason)
+    )
 
     if map_size(socket.subscriptions) > 0 do
       emit_terminate_telemetry(socket, reason)
@@ -329,16 +333,6 @@ defmodule Absinthe.GraphqlWS.Transport do
       %{socket_subscription_count: 0},
       metadata
     )
-  end
-
-  defp emit_transport_terminate_telemetry(socket, reason) do
-    measurements = %{socket_subscription_count: map_size(socket.subscriptions)}
-
-    metadata =
-      socket_metadata(socket)
-      |> Map.put(:reason, reason)
-
-    :telemetry.execute([:absinthe_graphql_ws, :transport, :terminate], measurements, metadata)
   end
 
   defp emit_subscribe_success(socket, id, operation_name) do

--- a/lib/absinthe/graphql_ws/transport.ex
+++ b/lib/absinthe/graphql_ws/transport.ex
@@ -177,13 +177,6 @@ defmodule Absinthe.GraphqlWS.Transport do
     :telemetry.execute([:absinthe_graphql_ws, :transport, :terminate], measurements, metadata)
   end
 
-  @doc false
-  @spec emit_transport_init(socket()) :: :ok
-  def emit_transport_init(socket) do
-    :telemetry.execute([:absinthe_graphql_ws, :transport, :init], %{}, socket_metadata(socket))
-    :ok
-  end
-
   @doc """
   Callbacks for parsed JSON payloads coming in from a client.
 

--- a/lib/absinthe/graphql_ws/transport.ex
+++ b/lib/absinthe/graphql_ws/transport.ex
@@ -156,8 +156,24 @@ defmodule Absinthe.GraphqlWS.Transport do
   @spec terminate(term(), socket()) :: :ok
   def terminate(reason, socket) do
     debug("terminated: #{inspect(reason)}")
-    emit_terminate_telemetry(socket, reason)
+    emit_terminate_telemetry(reason, socket)
     :ok
+  end
+
+  defp emit_terminate_telemetry(reason, socket) do
+    subscriptions =
+      Enum.map(socket.subscriptions, fn {topic, _} ->
+        {id, operation_name} = subscription_info(socket.subscriptions, topic)
+        %{id: id, operation_name: operation_name}
+      end)
+
+    metadata =
+      socket_metadata(socket)
+      |> Map.merge(%{reason: reason, subscriptions: subscriptions})
+
+    measurements = %{socket_subscription_count: map_size(socket.subscriptions)}
+
+    :telemetry.execute([:absinthe_graphql_ws, :transport, :terminate], measurements, metadata)
   end
 
   @doc false
@@ -343,22 +359,6 @@ defmodule Absinthe.GraphqlWS.Transport do
       operation_name,
       measurements: %{socket_subscription_count: map_size(socket.subscriptions)}
     )
-  end
-
-  defp emit_terminate_telemetry(socket, reason) do
-    subscriptions =
-      Enum.map(socket.subscriptions, fn {topic, _} ->
-        {id, operation_name} = subscription_info(socket.subscriptions, topic)
-        %{id: id, operation_name: operation_name}
-      end)
-
-    metadata =
-      socket_metadata(socket)
-      |> Map.merge(%{reason: reason, subscriptions: subscriptions})
-
-    measurements = %{socket_subscription_count: map_size(socket.subscriptions)}
-
-    :telemetry.execute([:absinthe_graphql_ws, :transport, :terminate], measurements, metadata)
   end
 
   defp emit_operation_telemetry(event, socket, id, operation_name, opts \\ []) do

--- a/lib/absinthe/graphql_ws/transport.ex
+++ b/lib/absinthe/graphql_ws/transport.ex
@@ -246,7 +246,7 @@ defmodule Absinthe.GraphqlWS.Transport do
   def handle_inbound(%{"type" => "ping"}, socket) do
     system_time = System.system_time()
     message = Message.Pong.new()
-    measurements = %{payload_size: byte_size(message)}
+    measurements = %{payload_size: byte_size(message), socket_subscription_count: map_size(socket.subscriptions)}
     metadata = %{platform: get_platform(socket)}
     :telemetry.execute([:absinthe_graphql_ws, :handle_inbound, :ping], measurements, metadata)
 

--- a/lib/absinthe/graphql_ws/transport.ex
+++ b/lib/absinthe/graphql_ws/transport.ex
@@ -37,9 +37,7 @@ defmodule Absinthe.GraphqlWS.Transport do
 
   def handle_control({_, opcode: :pong}, socket) do
     start = socket.assigns[:start]
-    measurements = %{duration: System.monotonic_time() - start}
-    metadata = %{}
-    :telemetry.execute([:absinthe_graphql_ws, :keepalive, :stop], measurements, metadata)
+    emit_keepalive_stop_telemetry(System.monotonic_time() - start)
     system_time = System.system_time()
     socket = Util.assign(socket, last_inbound_pong: system_time, last_keepalive: system_time)
 
@@ -95,9 +93,7 @@ defmodule Absinthe.GraphqlWS.Transport do
   def handle_info(:keepalive, socket) do
     Process.send_after(self(), :keepalive, socket.keepalive)
     start = System.monotonic_time()
-    measurements = %{system_time: System.system_time()}
-    metadata = %{}
-    :telemetry.execute([:absinthe_graphql_ws, :keepalive, :start], measurements, metadata)
+    emit_keepalive_start_telemetry()
     system_time = System.system_time()
     socket = Util.assign(socket, start: start, last_outbound_ping: system_time, last_keepalive: system_time)
 
@@ -105,15 +101,7 @@ defmodule Absinthe.GraphqlWS.Transport do
   end
 
   def handle_info(:gc, socket) do
-    before_info = Process.info(self()) |> Map.new()
-
-    :telemetry.span([:absinthe_graphql_ws, :gc], %{before: before_info}, fn ->
-      :erlang.garbage_collect()
-      after_info = Process.info(self()) |> Map.new()
-
-      {:ok, %{before: before_info, after: after_info}}
-    end)
-
+    emit_gc_telemetry()
     maybe_schedule_gc(socket)
 
     {:ok, socket}
@@ -122,18 +110,7 @@ defmodule Absinthe.GraphqlWS.Transport do
   def handle_info(%Broadcast{event: "subscription:data", payload: payload, topic: topic}, socket) do
     {subscription_id, operation_name} = subscription_info(socket.subscriptions, topic)
     message = Message.Next.new(subscription_id, payload.result)
-    measurements = %{payload_size: byte_size(message)}
-
-    metadata = %{
-      platform: get_platform(socket),
-      session_id: get_session_id(socket),
-      client_app_version: get_client_app_version(socket),
-      user_id: get_user_id(socket),
-      payload: payload,
-      operation_name: operation_name
-    }
-
-    :telemetry.execute([:absinthe_graphql_ws, :handle_info, :broadcast], measurements, metadata)
+    emit_broadcast_telemetry(socket, operation_name, payload, message)
 
     {:push, {:text, message}, socket}
   end
@@ -156,25 +133,19 @@ defmodule Absinthe.GraphqlWS.Transport do
   @spec terminate(term(), socket()) :: :ok
   def terminate(reason, socket) do
     debug("terminated: #{inspect(reason)}")
-    emit_terminate_telemetry(reason, socket)
+    emit_transport_terminate_telemetry(reason, socket)
     :ok
   end
 
-  defp emit_terminate_telemetry(reason, socket) do
-    subscriptions =
-      Enum.map(socket.subscriptions, fn {topic, _} ->
-        {id, operation_name} = subscription_info(socket.subscriptions, topic)
-        %{id: id, operation_name: operation_name}
-      end)
+  @doc false
+  @spec init(socket()) :: {:ok, socket()}
+  def init(socket) do
+    emit_transport_init_telemetry(socket)
 
-    metadata =
-      socket
-      |> socket_metadata()
-      |> Map.merge(%{reason: reason, subscriptions: subscriptions})
+    if socket.keepalive > 0,
+      do: Process.send_after(self(), :keepalive, socket.keepalive)
 
-    measurements = %{socket_subscription_count: map_size(socket.subscriptions)}
-
-    :telemetry.execute([:absinthe_graphql_ws, :transport, :terminate], measurements, metadata)
+    {:ok, socket}
   end
 
   @doc """
@@ -185,15 +156,7 @@ defmodule Absinthe.GraphqlWS.Transport do
   """
   @spec handle_inbound(map(), socket()) :: reply_inbound()
   def handle_inbound(%{"type" => "connection_init"}, %{initialized?: true} = socket) do
-    metadata = %{
-      code: 4429,
-      operation: :connection_init,
-      reason: :too_many_initialisation_requests,
-      platform: get_platform(socket)
-    }
-
-    :telemetry.execute([:absinthe_graphql_ws, :handle_inbound, :error], %{}, metadata)
-
+    emit_handle_inbound_error_telemetry(socket, 4429, :connection_init, :too_many_initialisation_requests)
     close(4429, "Too many initialisation requests", socket)
   end
 
@@ -218,15 +181,7 @@ defmodule Absinthe.GraphqlWS.Transport do
   end
 
   def handle_inbound(%{"type" => "subscribe"}, %{initialized?: false} = socket) do
-    metadata = %{
-      code: 4400,
-      operation: :subscribe,
-      reason: :subscribe_before_connection_init,
-      platform: get_platform(socket)
-    }
-
-    :telemetry.execute([:absinthe_graphql_ws, :handle_inbound, :error], %{}, metadata)
-
+    emit_handle_inbound_error_telemetry(socket, 4400, :subscribe, :subscribe_before_connection_init)
     close(4400, "Subscribe message received before ConnectionInit", socket)
   end
 
@@ -247,7 +202,7 @@ defmodule Absinthe.GraphqlWS.Transport do
       {:ok, topic, operation_name} ->
         debug("unsubscribing from topic #{topic}")
         unsubscribe_topic_with_telemetry(socket, topic, id, operation_name)
-        emit_complete_success(socket, id, operation_name)
+        emit_complete_telemetry(socket, id, operation_name)
 
         {:ok, %{socket | subscriptions: Map.delete(socket.subscriptions, topic)}}
 
@@ -259,9 +214,7 @@ defmodule Absinthe.GraphqlWS.Transport do
   def handle_inbound(%{"type" => "ping"}, socket) do
     system_time = System.system_time()
     message = Message.Pong.new()
-    measurements = %{payload_size: byte_size(message), socket_subscription_count: map_size(socket.subscriptions)}
-    metadata = %{platform: get_platform(socket)}
-    :telemetry.execute([:absinthe_graphql_ws, :handle_inbound, :ping], measurements, metadata)
+    emit_handle_inbound_ping_telemetry(socket, message)
 
     socket = Util.assign(socket, last_inbound_ping: system_time, last_keepalive: system_time)
     {:reply, :ok, {:text, message}, socket}
@@ -305,14 +258,14 @@ defmodule Absinthe.GraphqlWS.Transport do
   end
 
   defp tap_subscribe_success({:ok, socket} = result, _socket, id, operation_name) do
-    emit_subscribe_success(socket, id, operation_name)
+    emit_subscribe_telemetry(socket, id, operation_name)
     result
   end
 
   defp tap_subscribe_success({:reply, :ok, {:text, message}, socket} = result, _socket, id, operation_name) do
     case Util.json_library().decode(message) do
       {:ok, %{"type" => "next"}} ->
-        emit_subscribe_success(socket, id, operation_name)
+        emit_subscribe_telemetry(socket, id, operation_name)
 
       _ ->
         :ok
@@ -322,6 +275,67 @@ defmodule Absinthe.GraphqlWS.Transport do
   end
 
   defp tap_subscribe_success(result, _socket, _id, _operation_name), do: result
+
+  defp emit_transport_init_telemetry(socket) do
+    :telemetry.execute([:absinthe_graphql_ws, :transport, :init], %{}, socket_metadata(socket))
+  end
+
+  defp emit_transport_terminate_telemetry(reason, socket) do
+    subscriptions =
+      Enum.map(socket.subscriptions, fn {topic, _} ->
+        {id, operation_name} = subscription_info(socket.subscriptions, topic)
+        %{id: id, operation_name: operation_name}
+      end)
+
+    metadata =
+      socket_metadata(socket)
+      |> Map.merge(%{reason: reason, subscriptions: subscriptions})
+
+    measurements = %{socket_subscription_count: map_size(socket.subscriptions)}
+
+    :telemetry.execute([:absinthe_graphql_ws, :transport, :terminate], measurements, metadata)
+  end
+
+  defp emit_keepalive_start_telemetry do
+    :telemetry.execute(
+      [:absinthe_graphql_ws, :keepalive, :start],
+      %{system_time: System.system_time()},
+      %{}
+    )
+  end
+
+  defp emit_keepalive_stop_telemetry(duration) do
+    :telemetry.execute([:absinthe_graphql_ws, :keepalive, :stop], %{duration: duration}, %{})
+  end
+
+  defp emit_gc_telemetry do
+    before_info = Process.info(self()) |> Map.new()
+
+    :telemetry.span([:absinthe_graphql_ws, :gc], %{before: before_info}, fn ->
+      :erlang.garbage_collect()
+      after_info = Process.info(self()) |> Map.new()
+
+      {:ok, %{before: before_info, after: after_info}}
+    end)
+  end
+
+  defp emit_broadcast_telemetry(socket, operation_name, payload, message) do
+    metadata =
+      socket_metadata(socket)
+      |> Map.merge(%{payload: payload, operation_name: operation_name})
+
+    measurements = %{payload_size: byte_size(message)}
+
+    :telemetry.execute([:absinthe_graphql_ws, :handle_info, :broadcast], measurements, metadata)
+  end
+
+  defp emit_handle_inbound_error_telemetry(socket, code, operation, reason) do
+    metadata =
+      socket_metadata(socket)
+      |> Map.merge(%{code: code, operation: operation, reason: reason})
+
+    :telemetry.execute([:absinthe_graphql_ws, :handle_inbound, :error], %{}, metadata)
+  end
 
   defp emit_connection_init_telemetry(socket) do
     metadata =
@@ -335,7 +349,20 @@ defmodule Absinthe.GraphqlWS.Transport do
     )
   end
 
-  defp emit_subscribe_success(socket, id, operation_name) do
+  defp emit_handle_inbound_ping_telemetry(socket, message) do
+    measurements = %{
+      payload_size: byte_size(message),
+      socket_subscription_count: map_size(socket.subscriptions)
+    }
+
+    :telemetry.execute(
+      [:absinthe_graphql_ws, :handle_inbound, :ping],
+      measurements,
+      socket_metadata(socket)
+    )
+  end
+
+  defp emit_subscribe_telemetry(socket, id, operation_name) do
     emit_operation_telemetry(
       [:absinthe_graphql_ws, :handle_inbound, :subscribe],
       socket,
@@ -345,7 +372,7 @@ defmodule Absinthe.GraphqlWS.Transport do
     )
   end
 
-  defp emit_complete_success(socket, id, operation_name) do
+  defp emit_complete_telemetry(socket, id, operation_name) do
     emit_operation_telemetry(
       [:absinthe_graphql_ws, :handle_inbound, :complete],
       socket,

--- a/test/integration/complete_telemetry_test.exs
+++ b/test/integration/complete_telemetry_test.exs
@@ -74,7 +74,7 @@ defmodule Absinthe.GraphqlWS.CompleteTelemetryTest do
     assert Map.has_key?(start_measurements, :system_time)
 
     assert start_metadata.id == id
-    assert start_metadata.socket_subscription_count == 1
+    refute Map.has_key?(start_metadata, :socket_subscription_count)
     assert is_integer(start_metadata.memory_before)
     assert is_integer(start_metadata.message_queue_len_before)
 
@@ -84,7 +84,7 @@ defmodule Absinthe.GraphqlWS.CompleteTelemetryTest do
     assert is_integer(stop_measurements.duration)
 
     assert stop_metadata.id == id
-    assert stop_metadata.socket_subscription_count == 1
+    refute Map.has_key?(stop_metadata, :socket_subscription_count)
     assert is_integer(stop_metadata.memory_before)
     assert is_integer(stop_metadata.memory_after)
     assert is_integer(stop_metadata.memory_delta)
@@ -94,8 +94,8 @@ defmodule Absinthe.GraphqlWS.CompleteTelemetryTest do
 
     assert_receive {:telemetry, :execute, [:absinthe_graphql_ws, :handle_inbound, :complete], execute_measurements, execute_metadata}
 
-    assert execute_measurements == %{}
+    assert execute_measurements == %{socket_subscription_count: 1}
     assert execute_metadata.id == id
-    assert execute_metadata.socket_subscription_count == 1
+    refute Map.has_key?(execute_metadata, :socket_subscription_count)
   end
 end

--- a/test/integration/complete_telemetry_test.exs
+++ b/test/integration/complete_telemetry_test.exs
@@ -1,39 +1,25 @@
 defmodule Absinthe.GraphqlWS.CompleteTelemetryTest do
   use ExUnit.Case
 
-  @span_handler_id {__MODULE__, :complete_span}
-  @execute_handler_id {__MODULE__, :complete_execute}
+  @handler_id {__MODULE__, :complete_span}
 
   setup context do
     parent = self()
 
     :ok =
       :telemetry.attach_many(
-        @span_handler_id,
+        @handler_id,
         [
           [:absinthe_graphql_ws, :handle_inbound, :complete, :start],
           [:absinthe_graphql_ws, :handle_inbound, :complete, :stop]
         ],
         fn event, measurements, metadata, _config ->
-          send(parent, {:telemetry, :span, event, measurements, metadata})
+          send(parent, {:telemetry, event, measurements, metadata})
         end,
         nil
       )
 
-    :ok =
-      :telemetry.attach(
-        @execute_handler_id,
-        [:absinthe_graphql_ws, :handle_inbound, :complete],
-        fn event, measurements, metadata, _config ->
-          send(parent, {:telemetry, :execute, event, measurements, metadata})
-        end,
-        nil
-      )
-
-    on_exit(fn ->
-      :telemetry.detach(@span_handler_id)
-      :telemetry.detach(@execute_handler_id)
-    end)
+    on_exit(fn -> :telemetry.detach(@handler_id) end)
 
     assert {:ok, client} = Test.Client.start()
     on_exit(fn -> Test.Client.close(client) end)
@@ -44,7 +30,7 @@ defmodule Absinthe.GraphqlWS.CompleteTelemetryTest do
     Map.merge(context, %{client: client})
   end
 
-  test "emits a performance span and lifecycle execute around unsubscribe", %{client: client} do
+  test "emits unsubscribe span with lifecycle count on stop", %{client: client} do
     id = "subscription-to-unsubscribe"
 
     :ok =
@@ -68,7 +54,7 @@ defmodule Absinthe.GraphqlWS.CompleteTelemetryTest do
 
     :ok = Test.Client.push(client, %{id: id, type: "complete"})
 
-    assert_receive {:telemetry, :span, [:absinthe_graphql_ws, :handle_inbound, :complete, :start], start_measurements, start_metadata}
+    assert_receive {:telemetry, [:absinthe_graphql_ws, :handle_inbound, :complete, :start], start_measurements, start_metadata}
 
     assert Map.has_key?(start_measurements, :monotonic_time)
     assert Map.has_key?(start_measurements, :system_time)
@@ -78,24 +64,19 @@ defmodule Absinthe.GraphqlWS.CompleteTelemetryTest do
     assert is_integer(start_metadata.memory_before)
     assert is_integer(start_metadata.message_queue_len_before)
 
-    assert_receive {:telemetry, :span, [:absinthe_graphql_ws, :handle_inbound, :complete, :stop], stop_measurements, stop_metadata}
+    assert_receive {:telemetry, [:absinthe_graphql_ws, :handle_inbound, :complete, :stop], stop_measurements, stop_metadata}
 
     assert Map.has_key?(stop_measurements, :duration)
     assert is_integer(stop_measurements.duration)
+    assert stop_measurements.socket_subscription_count == 1
+    refute Map.has_key?(stop_metadata, :socket_subscription_count)
 
     assert stop_metadata.id == id
-    refute Map.has_key?(stop_metadata, :socket_subscription_count)
     assert is_integer(stop_metadata.memory_before)
     assert is_integer(stop_metadata.memory_after)
     assert is_integer(stop_metadata.memory_delta)
     assert stop_metadata.memory_delta == stop_metadata.memory_after - stop_metadata.memory_before
     assert is_integer(stop_metadata.message_queue_len_before)
     assert is_integer(stop_metadata.message_queue_len_after)
-
-    assert_receive {:telemetry, :execute, [:absinthe_graphql_ws, :handle_inbound, :complete], execute_measurements, execute_metadata}
-
-    assert execute_measurements == %{socket_subscription_count: 1}
-    assert execute_metadata.id == id
-    refute Map.has_key?(execute_metadata, :socket_subscription_count)
   end
 end

--- a/test/integration/connection_init_telemetry_test.exs
+++ b/test/integration/connection_init_telemetry_test.exs
@@ -1,0 +1,41 @@
+defmodule Absinthe.GraphqlWS.ConnectionInitTelemetryTest do
+  use ExUnit.Case
+
+  @handler_id {__MODULE__, :connection_init}
+
+  setup context do
+    parent = self()
+
+    :ok =
+      :telemetry.attach(
+        @handler_id,
+        [:absinthe_graphql_ws, :handle_inbound, :connection_init],
+        fn event, measurements, metadata, _config ->
+          send(parent, {:telemetry, event, measurements, metadata})
+        end,
+        nil
+      )
+
+    on_exit(fn -> :telemetry.detach(@handler_id) end)
+
+    assert {:ok, client} = Test.Client.start()
+    on_exit(fn -> Test.Client.close(client) end)
+
+    Map.merge(context, %{client: client})
+  end
+
+  test "emits lifecycle telemetry on successful connection_init", %{client: client} do
+    :ok = Test.Client.push(client, %{type: "connection_init"})
+
+    assert_receive {
+      :telemetry,
+      [:absinthe_graphql_ws, :handle_inbound, :connection_init],
+      measurements,
+      metadata
+    }
+
+    assert measurements == %{socket_subscription_count: 0}
+    assert metadata.platform == "unknown"
+    refute Map.has_key?(metadata, :socket_subscription_count)
+  end
+end

--- a/test/integration/ping_telemetry_test.exs
+++ b/test/integration/ping_telemetry_test.exs
@@ -1,0 +1,45 @@
+defmodule Absinthe.GraphqlWS.PingTelemetryTest do
+  use ExUnit.Case
+
+  @handler_id {__MODULE__, :ping}
+
+  setup context do
+    parent = self()
+
+    :ok =
+      :telemetry.attach(
+        @handler_id,
+        [:absinthe_graphql_ws, :handle_inbound, :ping],
+        fn event, measurements, metadata, _config ->
+          send(parent, {:telemetry, event, measurements, metadata})
+        end,
+        nil
+      )
+
+    on_exit(fn -> :telemetry.detach(@handler_id) end)
+
+    assert {:ok, client} = Test.Client.start()
+    on_exit(fn -> Test.Client.close(client) end)
+
+    :ok = Test.Client.push(client, %{type: "connection_init"})
+    assert {:ok, [{:text, _}]} = Test.Client.get_new_replies(client)
+
+    Map.merge(context, %{client: client})
+  end
+
+  test "emits socket_subscription_count in measurements on ping", %{client: client} do
+    :ok = Test.Client.push(client, %{type: "ping", payload: %{}})
+
+    assert_receive {
+      :telemetry,
+      [:absinthe_graphql_ws, :handle_inbound, :ping],
+      measurements,
+      metadata
+    }
+
+    assert Map.has_key?(measurements, :payload_size)
+    assert measurements.socket_subscription_count == 0
+    assert metadata.platform == "unknown"
+    refute Map.has_key?(metadata, :socket_subscription_count)
+  end
+end

--- a/test/integration/subscribe_telemetry_test.exs
+++ b/test/integration/subscribe_telemetry_test.exs
@@ -1,0 +1,63 @@
+defmodule Absinthe.GraphqlWS.SubscribeTelemetryTest do
+  use ExUnit.Case
+
+  @handler_id {__MODULE__, :subscribe}
+
+  setup context do
+    parent = self()
+
+    :ok =
+      :telemetry.attach(
+        @handler_id,
+        [:absinthe_graphql_ws, :handle_inbound, :subscribe],
+        fn event, measurements, metadata, _config ->
+          send(parent, {:telemetry, event, measurements, metadata})
+        end,
+        nil
+      )
+
+    on_exit(fn -> :telemetry.detach(@handler_id) end)
+
+    assert {:ok, client} = Test.Client.start()
+    on_exit(fn -> Test.Client.close(client) end)
+
+    :ok = Test.Client.push(client, %{type: "connection_init"})
+    assert {:ok, [{:text, _}]} = Test.Client.get_new_replies(client)
+
+    Map.merge(context, %{client: client})
+  end
+
+  test "emits socket_subscription_count in measurements after subscribe", %{client: client} do
+    id = "subscription-count-test"
+
+    :ok =
+      Test.Client.push(client, %{
+        id: id,
+        type: "subscribe",
+        payload: %{
+          query: """
+          subscription ThingChanges($id: Int!) {
+            thing_changes(id: $id) {
+              id
+              name
+            }
+          }
+          """,
+          variables: %{id: 2}
+        }
+      })
+
+    assert {:ok, []} = Test.Client.get_new_replies(client)
+
+    assert_receive {
+      :telemetry,
+      [:absinthe_graphql_ws, :handle_inbound, :subscribe],
+      measurements,
+      metadata
+    }
+
+    assert measurements == %{socket_subscription_count: 1}
+    assert metadata.id == id
+    refute Map.has_key?(metadata, :socket_subscription_count)
+  end
+end

--- a/test/integration/transport_telemetry_test.exs
+++ b/test/integration/transport_telemetry_test.exs
@@ -61,7 +61,50 @@ defmodule Absinthe.GraphqlWS.TransportTelemetryTest do
 
     assert terminate_measurements == %{socket_subscription_count: 0}
     assert terminate_metadata.platform == "unknown"
+    assert terminate_metadata.subscriptions == []
     assert is_atom(terminate_metadata.reason) or is_binary(terminate_metadata.reason)
     refute Map.has_key?(terminate_metadata, :socket_subscription_count)
+  end
+
+  test "includes orphaned subscriptions in transport terminate metadata" do
+    assert {:ok, client} = Test.Client.start()
+
+    assert_receive {:telemetry, :init, _, _, _}
+
+    :ok = Test.Client.push(client, %{type: "connection_init"})
+    assert {:ok, [{:text, _}]} = Test.Client.get_new_replies(client)
+
+    id = "orphaned-subscription"
+
+    :ok =
+      Test.Client.push(client, %{
+        id: id,
+        type: "subscribe",
+        payload: %{
+          query: """
+          subscription ThingChanges($id: Int!) {
+            thing_changes(id: $id) {
+              id
+              name
+            }
+          }
+          """,
+          variables: %{id: 2}
+        }
+      })
+
+    assert {:ok, []} = Test.Client.get_new_replies(client)
+
+    :ok = Test.Client.close(client)
+
+    assert_receive {
+      :telemetry,
+      :terminate,
+      [:absinthe_graphql_ws, :transport, :terminate],
+      %{socket_subscription_count: 1},
+      terminate_metadata
+    }
+
+    assert [%{id: ^id, operation_name: nil}] = terminate_metadata.subscriptions
   end
 end

--- a/test/integration/transport_telemetry_test.exs
+++ b/test/integration/transport_telemetry_test.exs
@@ -1,0 +1,67 @@
+defmodule Absinthe.GraphqlWS.TransportTelemetryTest do
+  use ExUnit.Case
+
+  @init_handler_id {__MODULE__, :transport_init}
+  @terminate_handler_id {__MODULE__, :transport_terminate}
+
+  setup context do
+    parent = self()
+
+    :ok =
+      :telemetry.attach(
+        @init_handler_id,
+        [:absinthe_graphql_ws, :transport, :init],
+        fn event, measurements, metadata, _config ->
+          send(parent, {:telemetry, :init, event, measurements, metadata})
+        end,
+        nil
+      )
+
+    :ok =
+      :telemetry.attach(
+        @terminate_handler_id,
+        [:absinthe_graphql_ws, :transport, :terminate],
+        fn event, measurements, metadata, _config ->
+          send(parent, {:telemetry, :terminate, event, measurements, metadata})
+        end,
+        nil
+      )
+
+    on_exit(fn ->
+      :telemetry.detach(@init_handler_id)
+      :telemetry.detach(@terminate_handler_id)
+    end)
+
+    context
+  end
+
+  test "emits transport init and terminate lifecycle telemetry" do
+    assert {:ok, client} = Test.Client.start()
+
+    assert_receive {
+      :telemetry,
+      :init,
+      [:absinthe_graphql_ws, :transport, :init],
+      init_measurements,
+      init_metadata
+    }
+
+    assert init_measurements == %{}
+    assert init_metadata.platform == "unknown"
+
+    :ok = Test.Client.close(client)
+
+    assert_receive {
+      :telemetry,
+      :terminate,
+      [:absinthe_graphql_ws, :transport, :terminate],
+      terminate_measurements,
+      terminate_metadata
+    }
+
+    assert terminate_measurements == %{socket_subscription_count: 0}
+    assert terminate_metadata.platform == "unknown"
+    assert is_atom(terminate_metadata.reason) or is_binary(terminate_metadata.reason)
+    refute Map.has_key?(terminate_metadata, :socket_subscription_count)
+  end
+end


### PR DESCRIPTION
## Summary
- Emit missing fork lifecycle events for `connection_init`, `transport:init`, and `transport:terminate` so live-api can map `fan.graphql.ws.*` counters from telemetry handlers instead of inline socket calls.
- Move `socket_subscription_count` into telemetry **measurements** on subscribe, complete (`:stop`), ping, `connection_init`, and `transport:terminate`; remove it from unsubscribe span metadata.
- **Consolidate socket shutdown telemetry:** one always-on `[:absinthe_graphql_ws, :transport, :terminate]` event replaces the former `[:absinthe_graphql_ws, :terminate, :complete]` event.
- **Consolidate client complete telemetry:** `[:handle_inbound, :complete, :stop]` is the single lifecycle point (counter + perf). Removed separate `[:handle_inbound, :complete]` execute — `socket_subscription_count` is on span stop measurements.
- Centralize telemetry in `Transport`: public callbacks call private `emit_*_telemetry/…` helpers; complete uses hand-rolled `:start`/`:stop` executes in `unsubscribe_topic_with_telemetry/4` (not `:telemetry.span/3`, so stop measurements can include `socket_subscription_count`). `Socket.init/1` delegates to `Transport.init/1` (same pattern as `terminate/2`). Document all events in `README.md` (bullet lists).

## Telemetry events

All events use the `[:absinthe_graphql_ws, …]` prefix. Shared socket metadata (`platform`, `session_id`, `client_app_version`, `user_id`) is included on most events via `socket.assigns`.

### Transport lifecycle
| Event | When | Measurements | Metadata |
| --- | --- | --- | --- |
| `:transport, :init` | WS upgrade (`Transport.init/1`) | — | socket metadata |
| `:transport, :terminate` | Socket shutdown (always) | `socket_subscription_count` | socket metadata, `reason`, `subscriptions` |

### `handle_inbound`
| Event | When | Measurements | Metadata |
| --- | --- | --- | --- |
| `:handle_inbound, :connection_init` | Successful `connection_init` | `socket_subscription_count` (`0`) | socket metadata, `auth_status` |
| `:handle_inbound, :subscribe` | Post-subscribe / query-mutation `next` | `socket_subscription_count` | `id`, `operation_name`, socket metadata |
| `:handle_inbound, :complete, :start` | Client `complete` — unsubscribe start | `monotonic_time`, `system_time` | operation metadata, `memory_before`, `message_queue_len_before` |
| `:handle_inbound, :complete, :stop` | Client `complete` — unsubscribe end (**lifecycle counter**) | `duration`, `monotonic_time`, `socket_subscription_count` | start metadata + `memory_after`, `memory_delta`, `message_queue_len_after` |
| `:handle_inbound, :ping` | Client `ping` | `payload_size`, `socket_subscription_count` | socket metadata |
| `:handle_inbound, :error` | Protocol error before close | — | socket metadata, `code`, `operation`, `reason` |

### Other
| Event | When | Measurements | Metadata |
| --- | --- | --- | --- |
| `:handle_info, :broadcast` | Subscription publish | `payload_size` | socket metadata, `payload`, `operation_name` |
| `:keepalive, :start` | Outbound ping sent | `system_time` | — |
| `:keepalive, :stop` | Inbound pong received | `duration` | — |
| `:gc, :start` / `:stop` | Optional GC span (`gc_interval` assign) | start: `monotonic_time`, `system_time`; stop: `duration` | `before` / `after` process info |

**Removed:** `[:absinthe_graphql_ws, :terminate, :complete]`, `[:absinthe_graphql_ws, :handle_inbound, :complete]` (bare execute).

## Test plan
- [x] `mise exec -- mix test test/integration/*_telemetry_test.exs`
- [x] CI passes on GitHub Actions (Elixir 1.13.4 / OTP 25)

## Follow-up (live-api)
- Bump `absinthe_graphql_ws` and wire `Zero.Metrics.AbsintheSocket` handlers.
- Map `fan.graphql.ws.connection_init`, `.init`, `.terminate`, and `.complete` to the new events above.
- Map `fan.graphql.ws.complete` to `[:handle_inbound, :complete, :stop]` (not bare `:complete`).
- **Do not** attach to `[:terminate, :complete]` or `[:handle_inbound, :complete]` execute — removed.
- Add `fan.graphql.ws.socket_subscription_count` distribution from lifecycle measurement fields.

Linear: [PLA-1445](https://linear.app/fanaticscollect/issue/PLA-1445)