### PR TITLE
chore(PLA-1518): add websocket max heap guardrail

### DIFF
--- a/guides/installation.md
+++ b/guides/installation.md
@@ -33,6 +33,22 @@ defmodule MyAppWeb.GraphqlWSSocket do
 end
 ```
 
+Socket options can be passed to `use Absinthe.GraphqlWS.Socket`. For example, to cap each websocket
+process heap at 50 MB:
+
+```elixir
+defmodule MyAppWeb.GraphqlWSSocket do
+  use Absinthe.GraphqlWS.Socket,
+    schema: MyAppWeb.Schema,
+    max_heap_size: 50 * 1024 * 1024
+end
+```
+
+`max_heap_size` is configured in bytes. The library converts it to BEAM words and applies
+`Process.flag(:max_heap_size, %{size: words, kill: true, error_logger: true})` inside each websocket
+process. Applications that need metrics for heap-limit kills should consume the OTP Logger report
+emitted by `error_logger: true` through their normal log pipeline.
+
 ## Phoenix endpoint
 
 Now mount the socket in your Phoenix.Endpoint:

--- a/lib/absinthe/graphql_ws/socket.ex
+++ b/lib/absinthe/graphql_ws/socket.ex
@@ -8,6 +8,10 @@ defmodule Absinthe.GraphqlWS.Socket do
   * `schema` - required - The Absinthe schema for the current application (example: `MyAppWeb.Schema`)
   * `keepalive` - optional - Interval in milliseconds to send `:ping` control frames over the websocket.
     Defaults to `30_000` (30 seconds).
+  * `max_heap_size` - optional - Maximum heap size in bytes for each websocket process.
+    When set to a positive integer, the value is converted to BEAM words and applied with
+    `Process.flag(:max_heap_size, %{size: words, kill: true, error_logger: true})`.
+    Heap-limit kills are reported by OTP Logger.
   * `pipeline` - optional - A `{module, function}` tuple defining how to generate an Absinthe pipeline
     for each incoming message. Defaults to `{Absinthe.GraphqlWS.Socket, :absinthe_pipeline}`.
   ## Garbage Collection
@@ -58,6 +62,7 @@ defmodule Absinthe.GraphqlWS.Socket do
     :endpoint,
     :handler,
     :keepalive,
+    :max_heap_size,
     :pubsub,
     assigns: %{},
     initialized?: false,
@@ -74,6 +79,7 @@ defmodule Absinthe.GraphqlWS.Socket do
           endpoint: module(),
           initialized?: boolean(),
           keepalive: integer(),
+          max_heap_size: pos_integer() | nil,
           subscriptions: map()
         }
   @type socket() :: t()
@@ -239,6 +245,8 @@ defmodule Absinthe.GraphqlWS.Socket do
       @doc false
       @impl Phoenix.Socket.Transport
       def init(socket) do
+        Socket.__apply_max_heap_size__(socket)
+
         if socket.keepalive > 0,
           do: Process.send_after(self(), :keepalive, socket.keepalive)
 
@@ -291,6 +299,7 @@ defmodule Absinthe.GraphqlWS.Socket do
     pubsub = socket.endpoint.config(:pubsub_server)
     schema = Keyword.fetch!(options, :schema)
     keepalive = Keyword.get(options, :keepalive, @default_keepalive)
+    max_heap_size = Keyword.get(options, :max_heap_size)
 
     absinthe_config = %{
       opts: [
@@ -309,12 +318,54 @@ defmodule Absinthe.GraphqlWS.Socket do
         endpoint: socket.endpoint,
         handler: module,
         keepalive: keepalive,
+        max_heap_size: max_heap_size,
         pubsub: pubsub
       )
 
     debug("connect: #{socket}")
 
     {:ok, socket}
+  end
+
+  @doc false
+  @spec __apply_max_heap_size__(socket()) :: :ok
+  def __apply_max_heap_size__(%Socket{max_heap_size: max_heap_size})
+      when max_heap_size in [nil, 0] do
+    :ok
+  end
+
+  def __apply_max_heap_size__(%Socket{max_heap_size: max_heap_size})
+      when is_integer(max_heap_size) and max_heap_size < 0 do
+    :ok
+  end
+
+  def __apply_max_heap_size__(%Socket{max_heap_size: max_heap_size, handler: handler})
+      when is_integer(max_heap_size) do
+    max_heap_size_words = bytes_to_words(max_heap_size)
+
+    Process.flag(:max_heap_size, %{
+      size: max_heap_size_words,
+      kill: true,
+      error_logger: true
+    })
+
+    :telemetry.execute(
+      [:absinthe_graphql_ws, :socket, :max_heap_size, :set],
+      %{max_heap_size_bytes: max_heap_size, max_heap_size_words: max_heap_size_words},
+      %{handler: handler}
+    )
+
+    :ok
+  end
+
+  def __apply_max_heap_size__(%Socket{max_heap_size: max_heap_size}) do
+    raise ArgumentError,
+          ":max_heap_size must be a positive integer byte count, got: #{inspect(max_heap_size)}"
+  end
+
+  defp bytes_to_words(bytes) do
+    word_size = :erlang.system_info(:wordsize)
+    div(bytes + word_size - 1, word_size)
   end
 
   @doc """

--- a/test/integration/socket_test.exs
+++ b/test/integration/socket_test.exs
@@ -10,11 +10,10 @@ defmodule Absinthe.GraphqlWS.SocketTest do
   def send_connection_init(%{client: client}) do
     :ok = Test.Client.push(client, %{type: "connection_init"})
 
-    assert {:ok,
-            [
-              {:text, Jason.encode!(%{"type" => "connection_ack", "payload" => %{}})}
-            ]} ==
-             Test.Client.get_new_replies(client)
+    assert_json_received(client, %{
+      "payload" => %{},
+      "type" => "connection_ack"
+    })
 
     :ok
   end
@@ -33,7 +32,7 @@ defmodule Absinthe.GraphqlWS.SocketTest do
 
   defp assert_json_received(client, payload) do
     assert {:ok, [{:text, json}]} = Test.Client.get_new_replies(client)
-    assert json == Jason.encode!(payload)
+    assert Jason.decode!(json) == payload
   end
 
   describe "initalization" do
@@ -320,5 +319,59 @@ defmodule Absinthe.GraphqlWS.SocketTest do
       assert_receive({:subscription, %{}} = reply)
       assert reply == {:subscription, %{subscription_param: "boo"}}
     end
+  end
+
+  describe "max_heap_size" do
+    @telemetry_handler_id {__MODULE__, :max_heap_size_set}
+
+    test "sets the socket process max heap size from bytes" do
+      parent = self()
+
+      :ok =
+        :telemetry.attach(
+          @telemetry_handler_id,
+          [:absinthe_graphql_ws, :socket, :max_heap_size, :set],
+          fn event, measurements, metadata, _config ->
+            send(parent, {:telemetry, event, measurements, metadata})
+          end,
+          nil
+        )
+
+      on_exit(fn -> :telemetry.detach(@telemetry_handler_id) end)
+      Test.Site.TestPubSub.subscribe(:max_heap_size)
+
+      assert {:ok, client} = Test.Client.start(Test.Site.heap_guard_socket())
+      on_exit(fn -> Test.Client.close(client) end)
+
+      max_heap_size_bytes = Test.Site.heap_guard_max_heap_size_bytes()
+      max_heap_size_words = bytes_to_words(max_heap_size_bytes)
+
+      assert_receive {
+        :telemetry,
+        [:absinthe_graphql_ws, :socket, :max_heap_size, :set],
+        %{
+          max_heap_size_bytes: ^max_heap_size_bytes,
+          max_heap_size_words: ^max_heap_size_words
+        },
+        %{handler: Test.Site.HeapGuardSocket}
+      }
+
+      :ok = Test.Client.push(client, %{type: "connection_init"})
+
+      assert_receive {
+        :max_heap_size,
+        %{size: ^max_heap_size_words, kill: true, error_logger: true}
+      }
+
+      assert_json_received(client, %{
+        "payload" => %{},
+        "type" => "connection_ack"
+      })
+    end
+  end
+
+  defp bytes_to_words(bytes) do
+    word_size = :erlang.system_info(:wordsize)
+    div(bytes + word_size - 1, word_size)
   end
 end

--- a/test/support/test/client.ex
+++ b/test/support/test/client.ex
@@ -12,8 +12,8 @@ defmodule Test.Client do
     reply_buffer: []
   ]
 
-  def start, do: GenServer.start(__MODULE__, [])
-  def start_link, do: GenServer.start_link(__MODULE__, [])
+  def start(path \\ nil), do: GenServer.start(__MODULE__, path)
+  def start_link(path \\ nil), do: GenServer.start_link(__MODULE__, path)
 
   def close(pid) do
     :ok = GenServer.call(pid, :close)
@@ -25,10 +25,10 @@ defmodule Test.Client do
   def get_new_replies(pid), do: GenServer.call(pid, :get_new_replies, 5000)
   def push(pid, message), do: GenServer.call(pid, {:push, message})
 
-  def init(_args) do
+  def init(path) do
     host = to_charlist(Test.Site.host())
     port = Test.Site.port()
-    path = Test.Site.Endpoint.socket()
+    path = path || Test.Site.Endpoint.socket()
 
     with {:ok, gun_pid} <- :gun.open(host, port, %{retry: 0}),
          {:ok, _protocol} <- :gun.await_up(gun_pid, :timer.seconds(5)),

--- a/test/support/test/site.ex
+++ b/test/support/test/site.ex
@@ -3,8 +3,12 @@ defmodule Test.Site do
 
   @host "localhost"
   @port 29_876
+  @heap_guard_socket "/graphql_heap_guard"
+  @heap_guard_max_heap_size_bytes 1_048_576
   def host, do: @host
   def port, do: @port
+  def heap_guard_socket, do: @heap_guard_socket
+  def heap_guard_max_heap_size_bytes, do: @heap_guard_max_heap_size_bytes
 
   defmodule GraphSocket do
     use Absinthe.GraphqlWS.Socket, schema: Test.Site.Schema
@@ -13,6 +17,20 @@ defmodule Test.Site do
     def handle_message({:subscription, params}, socket) do
       Test.Site.TestPubSub.notify(:handle_message_callback, {:subscription, params})
       {:ok, socket}
+    end
+  end
+
+  defmodule HeapGuardSocket do
+    use Absinthe.GraphqlWS.Socket,
+      schema: Test.Site.Schema,
+      max_heap_size: 1_048_576
+
+    @impl Absinthe.GraphqlWS.Socket
+    def handle_init(_payload, socket) do
+      {:max_heap_size, max_heap_size} = Process.info(self(), :max_heap_size)
+      Test.Site.TestPubSub.notify(:max_heap_size, {:max_heap_size, max_heap_size})
+
+      {:ok, %{}, socket}
     end
   end
 
@@ -117,7 +135,7 @@ defmodule Test.Site do
 
     defp pubsub_name,
       do:
-        Application.get_env(:absinthe_graphql_ws, Test.Site.Endpoint)
+        Elixir.Application.get_env(:absinthe_graphql_ws, Test.Site.Endpoint)
         |> Keyword.fetch!(:pubsub_server)
   end
 
@@ -174,10 +192,19 @@ defmodule Test.Site do
     use Absinthe.Phoenix.Endpoint
 
     @socket "/graphql"
+    @heap_guard_socket "/graphql_heap_guard"
     def socket, do: @socket
 
     socket @socket,
            Test.Site.GraphSocket,
+           websocket: [
+             connect_info: [:peer_data, :trace_context_headers, :x_headers, :uri, :user_agent],
+             path: "",
+             subprotocols: ["graphql-transport-ws"]
+           ]
+
+    socket @heap_guard_socket,
+           Test.Site.HeapGuardSocket,
            websocket: [
              connect_info: [:peer_data, :trace_context_headers, :x_headers, :uri, :user_agent],
              path: "",


### PR DESCRIPTION
## Summary
- Add a byte-based `max_heap_size` socket option that applies BEAM `:max_heap_size` with `kill: true` and `error_logger: true` in the websocket transport process.
- Emit deterministic telemetry when the heap guard is configured, including byte and word limits.
- Document OTP Logger-based kill reporting and add integration coverage for the configured process flag.

## Test plan
- `mise exec -- mix format lib/absinthe/graphql_ws/socket.ex test/support/test/client.ex test/support/test/site.ex test/integration/socket_test.exs guides/installation.md`
- `mise exec -- mix test test/integration/socket_test.exs`